### PR TITLE
v4l-dm800 siano: always load smsdvb

### DIFF
--- a/recipes-multimedia/v4l-dvb/files/v4l-dvb-smsdvb_always_load.patch
+++ b/recipes-multimedia/v4l-dvb/files/v4l-dvb-smsdvb_always_load.patch
@@ -1,0 +1,23 @@
+--- v4l-dvb-6e0befab696a/linux/drivers/media/dvb/siano/sms-cards.c.orig	2010-09-03 06:28:05.000000000 +0300
++++ v4l-dvb-6e0befab696a/linux/drivers/media/dvb/siano/sms-cards.c	2013-12-28 10:39:28.500757347 +0200
+@@ -294,19 +294,7 @@
+ 
+ int sms_board_load_modules(int id)
+ {
+-	switch (id) {
+-	case SMS1XXX_BOARD_HAUPPAUGE_CATAMOUNT:
+-	case SMS1XXX_BOARD_HAUPPAUGE_OKEMO_A:
+-	case SMS1XXX_BOARD_HAUPPAUGE_OKEMO_B:
+-	case SMS1XXX_BOARD_HAUPPAUGE_WINDHAM:
+-	case SMS1XXX_BOARD_HAUPPAUGE_TIGER_MINICARD:
+-	case SMS1XXX_BOARD_HAUPPAUGE_TIGER_MINICARD_R2:
+-		request_module("smsdvb");
+-		break;
+-	default:
+-		/* do nothing */
+-		break;
+-	}
++	request_module("smsdvb");
+ 	return 0;
+ }
+ EXPORT_SYMBOL_GPL(sms_board_load_modules);

--- a/recipes-multimedia/v4l-dvb/v4l-dvb-modules_hg.bb
+++ b/recipes-multimedia/v4l-dvb/v4l-dvb-modules_hg.bb
@@ -2,7 +2,7 @@ DEPENDS += "module-init-tools"
 RDEPENDS_${PN} += "module-init-tools-depmod"
 SRCDATE = "20100904"
 PV = "0.0+hg${SRCDATE}"
-PR = "${INC_PR}.2"
+PR = "${INC_PR}.3"
 
 SRC_URI = "hg://linuxtv.org/hg/;module=v4l-dvb;rev=${SRCREV} \
            file://defconfig \
@@ -47,6 +47,7 @@ SRC_URI = "hg://linuxtv.org/hg/;module=v4l-dvb;rev=${SRCREV} \
            file://v4l-dvb-em28xx_fix.patch \
            file://v4l-dvb-af9015_add_a850red.patch \
            file://v4l-dvb-smsdvb_fix_frontend.patch \
+           file://v4l-dvb-smsdvb_always_load.patch \
 "
 
 SRCREV = "6e0befab696a"


### PR DESCRIPTION
Backport patch into v4l.

[media] siano: always load smsdvb
Without smsdvb, the driver actually does nothing, as it lacks the userspace API. While I wrote it independently, in order to make a sms2270 board I have here to work, this patch is functionally identical to this patch from Doron Cohen: http://patchwork.linuxtv.org/patch/7894/

Patches for newer kernels (< 3.7 && >= 3.7) is available here: http://openpli.org/forums/topic/31523-august-dvb-t202-tuner/page-2#entry396227
Above patch obsoletes patch fix-dvb-siano-sms-order.patch
