### PR TITLE
Update libdca_0.0.5-5.bb

### DIFF
--- a/recipes-multimedia/vlc/libdca_0.0.5-5.bb
+++ b/recipes-multimedia/vlc/libdca_0.0.5-5.bb
@@ -12,9 +12,9 @@ S = "${WORKDIR}/git"
 inherit autotools lib_package pkgconfig
 
 do_unpackpost() {
-        QUILT_PATCHES=debian/patches quilt push -a
-        # single precision is enough and speeds up libdca by about 10-15%
-        sed -i -e 's/double/sample_t/g' ${S}/libdca/*.c ${S}/libdca/*.h
+    QUILT_PATCHES=debian/patches quilt push -a
+    # single precision is enough and speeds up libdca by about 10-15%
+    sed -i -e 's/double/sample_t/g' ${S}/libdca/*.c ${S}/libdca/*.h
 }
 
-addtask unpackpost after do_unpack before do_patch
+addtask unpackpost after do_patch before do_configure


### PR DESCRIPTION
libdca: Depend on quilt-native and move the patching to a later point

```
Apply the debian patches after "do_patch", not before.
Depend explicitly on quilt since we use it in the recipe.
```
