### PR TITLE
[autofs] Specify location of maps.

### DIFF
--- a/recipes-daemons/autofs/autofs_5.0.7.bbappend
+++ b/recipes-daemons/autofs/autofs_5.0.7.bbappend
@@ -1,10 +1,10 @@
-PRINC = "12"
+PRINC = "13"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " file://volatiles.99_autofs file://auto.network file://autofs.default"
 
-EXTRA_OECONF += "--with-confdir=/etc/default"
+EXTRA_OECONF += "--with-confdir=/etc/default --with-mapdir=/etc"
 
 # Remove bash scripting from init script (meaning, remove "function"
 # from each shell function)


### PR DESCRIPTION
Configure uses host setting as the default location for maps. That does not work out
too well when building on Gentoo, since the target autofs will look for maps in the
wrong place.
