### PR TITLE
Create em28xx_add_ub425_61959.patch

### DIFF
--- a/meta-brands/meta-ini/recipes-linux/linux-ini-3.3.8/em28xx_add_ub425_61959.patch
+++ b/meta-brands/meta-ini/recipes-linux/linux-ini-3.3.8/em28xx_add_ub425_61959.patch
@@ -1,0 +1,125 @@
+diff --git a/drivers/media/video/em28xx/em28xx-cards.c b/drivers/media/video/em28xx/em28xx-cards.c
+--- a/drivers/media/video/em28xx/em28xx-cards.c
++++ b/drivers/media/video/em28xx/em28xx-cards.c
+@@ -351,6 +351,19 @@ static struct em28xx_reg_seq hauppauge_9
+ 	{EM2874_R80_GPIO,	0xa6,	0xff,	10},
+ 	{ -1,			-1,	-1,	-1},
+ };
++
++/* 1b80:e425 MaxMedia UB425-TC
++ * 1b80:e1cc DeLock 61959
++ * GPIO_6 - demod reset, 0=active
++ * GPIO_7 - LED, 0=active
++ */
++
++static struct em28xx_reg_seq maxmedia_ub25_tc[] = {
++	{EM2874_R80_GPIO,	0x83,	0xff,	100},
++	{EM2874_R80_GPIO,	0xc3,	0xff,	100}, /* GPIO_6 = 1 */
++	{EM2874_R80_GPIO,	0x43,	0xff,	000}, /* GPIO_7 = 0 */
++	{-1,			-1,	-1,	-1},
++}:
+ #endif
+ 
+ /*
+@@ -1908,6 +1921,31 @@ struct em28xx_board em28xx_boards[] = {
+ 			.amux     = EM28XX_AMUX_LINE_IN,
+ 		} },
+ 	},
++	/* 1b80:e425 MaxMedia UB425-TC
++	/* Empia EM2874B + Micronas DRX 3913KA2 + NXP TDA18271HDC2 */
++	[EM2874_BOARD_MAXMEDIA_UB425_TC] = {
++		.name		= "MaxMedia UB425-TC",
++		.tuner_type	= TUNER_ABSENT,
++		.tuner_gpio	= maxmedia_ub425_tc,
++		.has_dvb	= 1,
++		.ir_codes	= RC_MAP_REDDO,
++		.def_i2c_bus	= 1,
++		.i2c_speed	= EM28XX_I2C_CLK_WAIT_ENABLE |
++				 EM28XX_I2C_FREQ_400_KHZ,
++	},
++	/* 1b80:e1cc DeLock 61959
++	/* Empia EM2874B + Micronas DRX 3913KA2 + NXP TDA18271HDC2
++	/* mostly the same as MaxMedia UB425-TC but different remote /*
++	[EM2874_BOARD_DELOCK_61959] = {
++		.name		= "DeLock 61959",
++		.tuner_type	= TUNER_ABSENT,
++		.tuner_gpio	= maxmedia_ub425_tc,
++		.has_dvb	= 1,
++		.ir_codes	= RC_MAP_DELOCK_61959,
++		.def_i2c_bus	= 1,
++		.i2c_speed	= EM28XX_I2C_CLK_WAIT_ENABLE |
++				  EM28XX_I2C_FREQ_400_KHZ,
++	},
+ };
+ const unsigned int em28xx_bcount = ARRAY_SIZE(em28xx_boards);
+ 
+@@ -2059,6 +2097,10 @@ struct usb_device_id em28xx_id_table[] =
+ 			.driver_info = EM2860_BOARD_HT_VIDBOX_NW03 },
+ 	{ USB_DEVICE(0x1b80, 0xe309), /* Sveon STV40 */
+ 			.driver_info = EM2860_BOARD_EASYCAP },
++	{ USB_DEVICE(0x1b80, 0xe425),
++			.driver_info = EM2874_BOARD_MAXMEDIA_UB425_TC },
++	{ USB_DEVICE(0x1b80, 0xe1cc),
++			.driver_info = EM2874_BOARD_DELOCK_61959 },
+ 	{ },
+ };
+ MODULE_DEVICE_TABLE(usb, em28xx_id_table);
+diff --git a/drivers/media/video/em28xx/em28xx-dvb.c b/drivers/media/video/em28xx/em28xx-dvb.c
+--- a/drivers/media/video/em28xx/em28xx-dvb.c
++++ b/drivers/media/video/em28xx/em28xx-dvb.c
+@@ -327,6 +327,13 @@ struct drxk_config hauppauge_930c_drxk =
+ 	.chunk_size = 56,
+ };
+ 
++static struct drxk_config maxmedia_ub425_tc_drxk = {
++	.adr = 0x29,
++	.single_master = 1,
++	.no_i2c_bridge = 1,
++	.load_firmware_sync = true,
++};
++
+ static int drxk_gate_ctrl(struct dvb_frontend *fe, int enable)
+ {
+ 	struct em28xx_dvb *dvb = fe->sec_priv;
+@@ -938,6 +945,28 @@ static int em28xx_dvb_init(struct em28xx
+ 			dvb_attach(a8293_attach, dvb->fe[0], &dev->i2c_adap,
+ 				&em28xx_a8293_config);
+ 		break;
++	case EM2874_BOARD_DELOCK_61959:
++	case EM2874_BOARD_MAXMEDIA_UB425_TC:
++		/* attach demodulator */
++		dvb->fe[0] = dvb_attach(drxk_attach, &maxmedia_ub425_tc_drxk,
++				&dev->i2c_adap[dev->def_i2c_bus]);
++		if (dvb->fe[0]) {
++			/* disable I2C-gate */
++			dvb->fe[0].ops.i2c_gate_ctrl = NULL;
++		
++			/*attach tuner */
++			if (!dvb_attach(tda18271c2dd_attach, dvb->fe[0],
++					&dev->i2c_adap[dev->def_i2c_bus], 0x60)) {
++				dvb_frontend_detach(dvb->fe[0]);
++				result = -EINVAL;
++				goto out_free;
++			}
++		}
++		
++		/* TODO we need drx-3913k firmware in order to support DVB-T */
++		em28xx_info("MaxMedia UB425-TC/DeLock 61959: only DVB-C " \
++				"supported by that driver version\n");
++		break;
+ 	default:
+ 		em28xx_errdev("/2: The frontend of your DVB/ATSC card"
+ 				" isn't supported yet\n");
+
+diff --git a/drivers/media/video/em28xx/em28xx.h b/drivers/media/video/em28xx/em28xx.h
+--- a/drivers/media/video/em28xx/em28xx.h
++++ b/drivers/media/video/em28xx/em28xx.h
+@@ -125,6 +125,8 @@
+ #define EM2884_BOARD_HAUPPAUGE_WINTV_HVR_930C	  81
+ #define EM2884_BOARD_CINERGY_HTC_STICK		  82
+ #define EM2860_BOARD_HT_VIDBOX_NW03 		  83
++#define EM2874_BOARD_MAXMEDIA_UB425_TC		  84
++#define EM2874_BOARD_DELOCK_61959		  85
+ 
+ /* Limits minimum and default number of buffers */
+ #define EM28XX_MIN_BUF 4


### PR DESCRIPTION
Patch to add MaxMedia UB425 USB DVB-C and (similar except remotekeys) DeLock61959 DVB-C. DVB-T Frontends not yet supported.
