### PR TITLE
Create em28xx_add_disable_i2c_devices_option.patch

### DIFF
--- a/meta-brands/meta-ini/recipes-linux/linux-ini-hdp-3.14.2/em28xx_add_disable_i2c_devices_option.patch
+++ b/meta-brands/meta-ini/recipes-linux/linux-ini-hdp-3.14.2/em28xx_add_disable_i2c_devices_option.patch
@@ -1,0 +1,37 @@
+--- a/drivers/media/usb/em28xx/em28xx-cards.c
++++ b/drivers/media/usb/em28xx/em28xx-cards.c
+@@ -55,6 +55,14 @@ module_param(disable_usb_speed_check, in
+ MODULE_PARM_DESC(disable_usb_speed_check,
+                 "override min bandwidth requirement of 480M bps");
+
++static unsigned int disable_first_i2c_device;
++module_param(disable_first_i2c_device, int, 0444);
++MODULE_PARM_DESC(disable_first_i2c_device, "manual disable of 1st i2c-device on em2874");
++
++static unsigned int disable_second_i2c_device;
++module_param(disable_second_i2c_device, int, 0444);
++MODULE_PARM_DESC(disable_second_i2c_device, "manual disable of 2nd i2c-device on em2874");
++
+ static unsigned int card[]     = {[0 ... (EM28XX_MAXBOARDS - 1)] = -1U };
+ module_param_array(card,  int, NULL, 0444);
+ MODULE_PARM_DESC(card,     "card type");
+@@ -3041,7 +3049,8 @@ static int em28xx_init_dev(struct em28xx
+        if (dev->board.is_em2800)
+                retval = em28xx_i2c_register(dev, 0, EM28XX_I2C_ALGO_EM2800);
+        else
+-               retval = em28xx_i2c_register(dev, 0, EM28XX_I2C_ALGO_EM28XX);
++               if(disable_first_i2c_device == 0)
++                       retval = em28xx_i2c_register(dev, 0, EM28XX_I2C_ALGO_EM28XX);
+        if (retval < 0) {
+                em28xx_errdev("%s: em28xx_i2c_register bus 0 - error [%d]!\n",
+                        __func__, retval);
+@@ -3054,7 +3063,8 @@ static int em28xx_init_dev(struct em28xx
+                        retval = em28xx_i2c_register(dev, 1,
+                                                  EM28XX_I2C_ALGO_EM25XX_BUS_B);
+                else
+-                       retval = em28xx_i2c_register(dev, 1,
++                       if (disable_second_i2c_device == 0)
++                               retval = em28xx_i2c_register(dev, 1,
+                                                        EM28XX_I2C_ALGO_EM28XX);
+                if (retval < 0) {
+                        em28xx_errdev("%s: em28xx_i2c_register bus 1 - error [%d]!\n",


### PR DESCRIPTION
DeLock 61959 doesn`t work because of those patches to support second i2c_bus. Device fails because it tries to register both i2c_devs using the same sysfs-address.
To not bother other devices, adding a simple module option to disable specific i2c-device is a workaround that fixes the device for me now.
Furthermore, I had to add /lib/firmware/dvb-demod-drxk-01.fw manually (downloaded from net) and install all necessary modules + packages :
enigma2-plugins-driver-dvb-usb-em28xx
kernel-module-tuner
kernel-module-drxk
kernel-module-em28xx
kernel-module-em28xx-dvb
kernel-module-em28xx-alsa
kernel-module-tda18271c2dd

Will try to build own special enigma2-plugins-driver-dvb-usb-delock61959 for that card, that pulls in correct Modules, FW and stuff

Regards, p1ng
