### PR TITLE
Enable IPv6 for transcoding, ftp and telnet

### DIFF
--- a/meta-oe/recipes-core/busybox/busybox-1.22.1/vuduo2/inetd.conf
+++ b/meta-oe/recipes-core/busybox/busybox-1.22.1/vuduo2/inetd.conf
@@ -18,6 +18,6 @@
 #daytime	dgram	udp	wait	root	internal
 #time		stream	tcp	nowait	root	internal
 #time		dgram	udp	wait	root	internal
-ftp		stream	tcp	nowait	root	/usr/sbin/vsftpd	vsftpd
-telnet	stream	tcp	nowait	root	/usr/sbin/telnetd	telnetd
-8002	stream	tcp nowait	root	/usr/bin/transtreamproxy transtreamproxy
+ftp		stream	tcp6	nowait	root	/usr/sbin/vsftpd	vsftpd
+telnet	stream	tcp6	nowait	root	/usr/sbin/telnetd	telnetd
+8002	stream	tcp6 nowait	root	/usr/bin/transtreamproxy transtreamproxy


### PR DESCRIPTION
Doesn't harm IPv4-only or Dual Stack users, busybox creates Dual Stack sockets.
