### PR TITLE
GB Quad: Enable IPv6 for transcoding, ftp and telnet

### DIFF
--- a/meta-oe/recipes-core/busybox/busybox-1.22.1/gbquad/inetd.conf
+++ b/meta-oe/recipes-core/busybox/busybox-1.22.1/gbquad/inetd.conf
@@ -18,7 +18,7 @@
 #daytime	dgram	udp	wait	root	internal
 #time		stream	tcp	nowait	root	internal
 #time		dgram	udp	wait	root	internal
-ftp	stream	tcp	nowait	root	/usr/sbin/vsftpd	vsftpd	
+ftp	stream	tcp6	nowait	root	/usr/sbin/vsftpd	vsftpd	
 # ftp		stream	tcp	nowait	root	ftpd	ftpd -w /
-telnet	stream	tcp	nowait	root	/usr/sbin/telnetd	telnetd	
-8002	stream	tcp	nowait	root	/usr/bin/transtreamproxy	transtreamproxy	
+telnet	stream	tcp6	nowait	root	/usr/sbin/telnetd	telnetd	
+8002	stream	tcp6	nowait	root	/usr/bin/transtreamproxy	transtreamproxy	

--- a/meta-oe/recipes-core/busybox/busybox-1.22.1/gbquadplus/inetd.conf
+++ b/meta-oe/recipes-core/busybox/busybox-1.22.1/gbquadplus/inetd.conf
@@ -18,7 +18,7 @@
 #daytime	dgram	udp	wait	root	internal
 #time		stream	tcp	nowait	root	internal
 #time		dgram	udp	wait	root	internal
-ftp	stream	tcp	nowait	root	/usr/sbin/vsftpd	vsftpd	
+ftp	stream	tcp6	nowait	root	/usr/sbin/vsftpd	vsftpd	
 # ftp		stream	tcp	nowait	root	ftpd	ftpd -w /
-telnet	stream	tcp	nowait	root	/usr/sbin/telnetd	telnetd	
-8002	stream	tcp	nowait	root	/usr/bin/transtreamproxy	transtreamproxy	
+telnet	stream	tcp6	nowait	root	/usr/sbin/telnetd	telnetd	
+8002	stream	tcp6	nowait	root	/usr/bin/transtreamproxy	transtreamproxy	


### PR DESCRIPTION
Doesn't harm IPv4-only users, busybox creates Dual Stack sockets.

For Gigablue Quad and Quad Plus.
