### PR TITLE
Fix nasty lock/error

### DIFF
--- a/meta-oe/recipes-support/ntp/ntp/ntpdate.default
+++ b/meta-oe/recipes-support/ntp/ntp/ntpdate.default
@@ -3,5 +3,5 @@
 NTPSERVERS="pool.ntp.org"
 
 # Set to "yes" to write time to hardware clock on success
-UPDATE_HWCLOCK="yes"
+UPDATE_HWCLOCK="no"
 


### PR DESCRIPTION
We do neither have hwclock nor a RTC to set:
/etc/network/if-up.d/ntpdate-sync: line 45: hwclock: command not found
