### PR TITLE
Tryfix updates for old installations

### DIFF
--- a/meta-oe/recipes-core/busybox/busybox_1.22.1.bbappend
+++ b/meta-oe/recipes-core/busybox/busybox_1.22.1.bbappend
@@ -1,4 +1,5 @@
-PR .= ".3"
+PR = "r37"
+PR .= ".0"
 
 SRC_URI_IGNORED = " \
             file://0001-ifupdown-support-post-up-pre-down-hooks.patch \


### PR DESCRIPTION
Installations with
busybox 1.22.1-r33, 1.22.1-r34, 1.22.1-r35 or 1.22.1-r36
didn't update any longer als r33-r36 is newer than any r32.x
