### PR TITLE
linux-libc-headers: fix build old vuplus boxes with build environment with very long path

### DIFF
--- a/meta-oe/recipes-kernel/linux-libc-headers/linux-libc-headers-3.9/001-fix_kernel_build_xargs.patch
+++ b/meta-oe/recipes-kernel/linux-libc-headers/linux-libc-headers-3.9/001-fix_kernel_build_xargs.patch
@@ -1,0 +1,21 @@
+--- a/scripts/Makefile.headersinst	2013-03-11 12:04:39.034212322 +0100
++++ b/scripts/Makefile.headersinst	2013-03-11 12:06:17.462215866 +0100
+@@ -71,7 +71,7 @@
+ quiet_cmd_install = INSTALL $(printdir) ($(words $(all-files))\
+                             file$(if $(word 2, $(all-files)),s))
+       cmd_install = \
+-        $(PERL) $< $(installdir) $(SRCARCH) $(input-files); \
++        xargs $(PERL) $< $(installdir) $(SRCARCH) < $(INSTALL_HDR_PATH)/.input-files; \
+         for F in $(wrapper-files); do                                   \
+                 echo "\#include <asm-generic/$$F>" > $(installdir)/$$F;    \
+         done;                                                           \
+@@ -100,7 +100,9 @@
+ $(install-file): scripts/headers_install.pl $(input-files) FORCE
+ 	$(if $(unwanted),$(call cmd,remove),)
+ 	$(if $(wildcard $(dir $@)),,$(shell mkdir -p $(dir $@)))
++	@echo $(input-files) > $(INSTALL_HDR_PATH)/.input-files
+ 	$(call if_changed,install)
++	@rm $(INSTALL_HDR_PATH)/.input-files
+ 
+ else
+ __headerscheck: $(subdirs) $(check-file)

--- a/meta-oe/recipes-kernel/linux-libc-headers/linux-libc-headers_3.9.bb
+++ b/meta-oe/recipes-kernel/linux-libc-headers/linux-libc-headers_3.9.bb
@@ -1,6 +1,10 @@
 require recipes-kernel/linux-libc-headers/linux-libc-headers.inc
 
-PR = "5"
+PR = "6"
+
+SRC_URI += " \
+        file://001-fix_kernel_build_xargs.patch \
+"
 
 SRC_URI[md5sum] = "2220321a0a14d86200322e51dd5033e2"
 SRC_URI[sha256sum] = "97e48f31ed2197f4e7e4938d4fab8da522cf80e60c6ce69668b0805904499305"


### PR DESCRIPTION
Perhaps these box can be built using more recent libc-headers... however for now I applied same patch from 3.9.7 directory
