### PR TITLE
Remove old Webinterface

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugins/openvix/pluginnotwanted.patch
+++ b/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugins/openvix/pluginnotwanted.patch
@@ -98,6 +98,7 @@ index 4c72f8b..d1d5fe6 100644
 -	webadmin \
 -	webbouqueteditor \
  	webcamviewer \
+- webinterface \
 -	werbezapper \
 -	zaphistorybrowser \
  	zapstatistic \


### PR DESCRIPTION
This causes a bootloop on openvix. Missing dependency on epgrefresh.

http://www.world-of-satellite.com/showthread.php?50071-Web-interface-crash&p=389751&viewfull=1#post389751
http://www.world-of-satellite.com/showthread.php?50184-Constant-Crashing
