### PR TITLE
[Wetek] Create IPBox IR Remote Profile

### DIFF
--- a/meta-brands/meta-wetek/recipes-bsp/amremote/wetek_ipbox9900remote.conf
+++ b/meta-brands/meta-wetek/recipes-bsp/amremote/wetek_ipbox9900remote.conf
@@ -1,0 +1,63 @@
+# Remote Model AB IPBox 9900/99/55 HD for Wetek Play || OpenATV
+factory_code	= 0x79860001
+
+work_mode  	= 1
+repeat_enable 	= 1
+release_delay	= 150
+debug_enable 	= 1
+reg_control	= 0xfbe40
+
+key_begin
+    0x00 116    ;    POWER
+    0x40 113    ;    MUTE
+    0x0f 377    ;    DTV || KEY_TV
+    0x4a 385    ;    RADIO || KEY_RADIO
+    0x60 144    ;    FILES || KEY_FILE
+    0x16 150    ;    WWW || KEY_WWW
+    0x14 388    ;    TELETEXT || KEY_TEXT
+    0x61 365    ;    EPG
+    0x19 139    ;    MENU
+    0x62 109    ;    KEY_PAGEDOWN
+    0x63 104    ;    KEY_PAGEUP
+    0x04 174    ;    EXIT
+    0x1a 103    ;    UP
+    0x1b 108    ;    DOWN
+    0x11 105    ;    LEFT
+    0x0d 106    ;    RIGHT
+    0x08 28     ;    OK || ENTER || KEY_ENTER
+    0x53 167    ;    RECORD || KEY_RECORD
+    0x17 207    ;    PLAY || KEY_PLAY
+    0x1c 128    ;    STOP	||	KEY_STOP
+#   0x4c XXX    ;    UNUSED
+    0x64 168    ;    << || KEY_REWIND
+    0x52 119    ;    PAUSE || KEY_PAUSE
+#   0x4e XXX    ;    UNUSED
+    0x6e 208    ;    >> || KEY_FASTFORWARD
+    0x50 398    ;    RED
+    0x54 399    ;    GREEN
+    0x41 400    ;    YELLOW
+    0x51 401    ;    BLUE
+    0x10 402    ;    KEY_CHANNELUP
+    0x65 403    ;    KEY_CHANNELDOWN
+    0x1d 358    ;    INFO
+    0x66 115    ;    VOLUME + || KEY_VOLUMEUP
+    0x67 114    ;    VOLUME - || KEY_VOLUMEDOWN
+    0x03 2      ;    1
+    0x02 3    	;    2
+    0x01 4    	;    3
+    0x07 5    	;    4
+    0x06 6    	;    5
+    0x05 7    	;    6
+    0x0b 8    	;    7
+    0x0a 9    	;    8
+    0x09 10     ;    9
+    0x1f 405    ;    RECALL / Back to previous channel || KEY_LAST
+    0x0e 11     ;    0
+    0x1e 138    ;    HELP
+    0x68 364    ;    Toggle video mode -> Favorites || KEY_FAVORITES
+    0x69 362    ;    Toggle aspect ratio -> Program || KEY_PROGRAM
+#   0x69 XXX    ;    UNUSED / Restart CAM Reader
+    0x49 395    ;    Bouquet List || KEY_LIST
+    0x6a 370    ;    SUBTITLES
+    0x6b 392    ;    AUDIO
+key_end


### PR DESCRIPTION
Hello,
this commit adds profile for AB IPBox 9900/99/55 HD IR Remotes modified to work properly on Wetek. Following configuration was tested on openATV image, version 5.3 on Wetek Play.
