### PR TITLE
Change plugin blurayplayer git branch to master

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-extensions-blurayplayer.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-extensions-blurayplayer.bb
@@ -9,7 +9,7 @@ inherit gitpkgv
 SRCREV = "${AUTOREV}"
 PV = "1+git${SRCPV}"
 PKGV = "1+git${GITPKGV}"
-BRANCH = "udfread"
+BRANCH = "master"
 
 SRC_URI = "git://github.com/Taapat/enigma2-plugin-blurayplayer.git;branch=${BRANCH}"
 


### PR DESCRIPTION
Branch udfread is only a temporary test branch for openpli image, and therefore the plugin does not work on non openpli image.
I added in master libudfread support, so change back to this branch to use it for non openpli images.
