### PR TITLE
Update aotom_spark_procfs.patch

### DIFF
--- a/meta-brands/meta-fulan/recipes-drivers/fulan-dvb-modules/aotom_spark_procfs.patch
+++ b/meta-brands/meta-fulan/recipes-drivers/fulan-dvb-modules/aotom_spark_procfs.patch
@@ -265,7 +265,7 @@ new file mode 100644
 index 0000000..83fd4e4
 --- /dev/null
 +++ b/frontcontroller/aotom_spark/aotom_procfs.c
-@@ -0,0 +1,753 @@
+@@ -0,0 +1,752 @@
 +/*
 + * aotom_procfs.c
 + *
@@ -978,7 +978,6 @@ index 0000000..83fd4e4
 +  { "stb/fp/rtc_offset", aotom_read_rtc_offset, aotom_write_rtc_offset },
 +  { "stb/fp/aotom", NULL, aotom_write },
 +  { "stb/fp/led0_pattern", NULL, led0_pattern_write },
-+  { "stb/fp/led1_pattern", NULL, led1_pattern_write },
 +  { "stb/fp/wakeup_time", wakeup_time_read, wakeup_time_write },
 +  { "stb/fp/was_timer_wakeup", was_timer_wakeup_read, null_write },
 +  { "stb/fp/version", fp_version_read, NULL },


### PR DESCRIPTION
Kosmetik
So leuchtet der Punkt nicht mehr.
Dieser Punkt/LED ist für Fernbedienung als Bestätigung gedacht. Leuchtet hier aber sonst immer.
Daher mal deaktiviert.