### PR TITLE
dvbsnoop: move to PersianPros on github.

### DIFF
--- a/meta-oe/recipes-multimedia/dvbsnoop/dvbsnoop.bb
+++ b/meta-oe/recipes-multimedia/dvbsnoop/dvbsnoop.bb
@@ -1,15 +1,18 @@
+DESCRIPTION = "DVB / MPEG stream analyzer"
 SUMMARY = "DVB / MPEG stream analyzer"
+MAINTAINER = "PersianPros"
 AUTHOR = "Rainer Scherg <rasc@users.sourceforge.net>"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
-PV = "1.4.50"
-PR = "r1"
 
-SRC_URI = "http://sourceforge.net/projects/dvbsnoop/files/latest/download/dvbsnoop-${PV}.tar.gz"
+inherit gitpkgv
 
-SRC_URI[md5sum] = "68a5618c95b4372eea9ac5ec5005f299"
-SRC_URI[sha256sum] = "7658498b26a5d2a0242e81f0cfafa0e43a2bec56f8674e7ac197dfc310866ec6"
+SRCREV = "3af4a3ed257e15f133aa61b894d787a7feeb64a2"
+PV = "1.4.51"
+PKGV = "1+git${GITPKGV}"
 
-S = "${WORKDIR}/dvbsnoop-${PV}"
+SRC_URI = "git://github.com/persianpros/dvbsnoop.git;protocol=git"
+
+S = "${WORKDIR}/git"
 
 inherit autotools


### PR DESCRIPTION
Dvbsnoop hasn't been maintained for some time and needs some
patches. Move the source to PersianPros and maintain it there.
https://github.com/OpenPLi/openpli-oe-core/commit/8569648679c24070479a73d1dde55d793b508191 by https://github.com/eriksl