### PR TITLE
The rtl8xxxu drfiver does not actually work well with rtl8192cu chipsets.

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-network-drivers/enigma2-plugin-drivers-network-usb-rtl8192cu.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-network-drivers/enigma2-plugin-drivers-network-usb-rtl8192cu.bb
@@ -3,8 +3,11 @@ PACKAGE_ARCH = "all"
 
 require conf/license/license-gplv2.inc
 
+# kernel-module-rtl8xxxu doesn't seem to work well for rtl8192cu chips.
+#
+
 RRECOMMENDS_${PN} = " \
-    ${@base_contains("MACHINE_FEATURES", "linuxwifi", "kernel-module-rtl8xxxu", "rtl8192cu", d)} \
+    ${@base_contains("MACHINE_FEATURES", "linuxwifi", "kernel-module-rtl8xxxu kernel-module-rtl8192cu", "rtl8192cu", d)} \
     firmware-rtl8192cu \
     firmware-rtl8192cufw \
     "


### PR DESCRIPTION
So install rtl8192cu as well for liuxwifi - it will be used in preference.