### PR TITLE
The rtl8xxxu drfiver does not actually work well with rtl8192cu chips…

### DIFF
--- a/meta-oe/recipes-distros/openvix/image/enigma2-plugin-drivers-network-usb-rtl8192cu.bbappend
+++ b/meta-oe/recipes-distros/openvix/image/enigma2-plugin-drivers-network-usb-rtl8192cu.bbappend
@@ -1,0 +1,12 @@
+# Ensure we get kernel-module-rtl8192cu
+
+# kernel-module-rtl8xxxu doesn't seem to work well for rtl8192cu chips.
+# so redefine RRECOMMENDS_ from the *.bb file to include 
+# kernel-module-rtl8192cu
+#
+
+RRECOMMENDS_${PN} = " \
+    ${@base_contains("MACHINE_FEATURES", "linuxwifi", "kernel-module-rtl8xxxu kernel-module-rtl8192cu", "rtl8192cu", d)} \
+    firmware-rtl8192cu \
+    firmware-rtl8192cufw \
+    "


### PR DESCRIPTION
…ets.

So install rtl8192cu as well for liuxwifi - it will be used in preference.

Added here just for OpenVix as captain reckons that dogma is preferable to a working NIC.