### PR TITLE
[wetekplay2] Fix extending mSD free space to additional partition on …

### DIFF
--- a/meta-brands/meta-wetek/recipes-bsp/amlsetfb/wetekplay2/amlsetfb.sh
+++ b/meta-brands/meta-wetek/recipes-bsp/amlsetfb/wetekplay2/amlsetfb.sh
@@ -93,8 +93,18 @@ ln -sf /sys/class/leds/led-sys/brightness /dev/led0
 ln -sf /sys/class/leds/wetek\:blue\:ethled/brightness /dev/led1
 ln -sf /sys/class/leds/wetek\:blue\:wifiled/brightness /dev/led2
 
+export ROOT=
+# Parse command line options
+for x in $(cat /proc/cmdline); do
+	case $x in
+	root=*)
+		ROOT=${x#root=}
+		;;
+	esac
+done
+
 # only once
-if [ ! -e /etc/.sdpart ] && [ ! -e /dev/system ]; then
+if [ ! -e /etc/.sdpart ] && [ "$ROOT" = "/dev/mmcblk0p2" ]; then
 	parted /dev/mmcblk0 unit MB mkpart primary ext4 1100MB 95%
 	sync ; sync ;
 	umount -f /dev/mmcblk0p3


### PR DESCRIPTION
…first boot (check if booting is from mSD or internal storage)

@atvcaptain 
Please commit this pull, it fix current problem with extending mSD free space on first boot because EMMC driver is active in kernel and /dev/system is valid so script think booting is done from internal storage and not mSD.

Thanks.