### PR TITLE
[transmission] /etc/init.d/transmission: file does not exist

### DIFF
--- a/meta-oe/recipes-connectivity/transmission/transmission.inc
+++ b/meta-oe/recipes-connectivity/transmission/transmission.inc
@@ -16,7 +16,7 @@ inherit autotools update-rc.d gettext
 
 do_install_append() {
     install -d ${D}${sysconfdir}/init.d
-    install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/transmissiond
+    install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/transmission
     install -d ${D}${sysconfdir}/default
     install -m 0755 ${WORKDIR}/config ${D}${sysconfdir}/default/transmission-daemon
     install -d ${D}${localstatedir}/lib/transmission-daemon


### PR DESCRIPTION
update-rc.d: /etc/init.d/transmission: file does not exist
Collected errors:
 * pkg_run_script: package "transmission" postinst script returned status 1.
 * opkg_configure: transmission.postinst returned 1.