### PR TITLE
Only move the original install directories up a level if it is needed.

### DIFF
--- a/meta-oe/recipes-devtools/python/python-simplejson_%.bbappend
+++ b/meta-oe/recipes-devtools/python/python-simplejson_%.bbappend
@@ -1,6 +1,12 @@
 include python-package-split.inc
 
 do_install_append() {
+
+# If things were installed a level down. move them up:
+
+if [ -d ${D}/usr/lib/python2.7/site-packages/simplejson-${PV}*/simplejson ]; then
+    echo "Moving install up a level"
     mv ${D}/usr/lib/python2.7/site-packages/*/* ${D}/usr/lib/python2.7/site-packages/
+fi
     rm -rf ${D}/usr/lib/python2.7/site-packages/simplejson-${PV}*
 }


### PR DESCRIPTION
This module ended up with the files packaged one level too high in OpenViX 5.0 builds.

The issue is that the oe-3.4 + python 2.7.11 + 3.8.1-r1 produced:
```
 simplejson-3.8.1-py2.7-linux-x86_64.egg/EGG-INFO
 simplejson-3.8.1-py2.7-linux-x86_64.egg/simplejson
```
in `image/usr/lib/python2.7/site-packages`

**BUT** oe-4.0 + python 2.7.12 + 3.8.2-r1 produces
```
 simplejson
 simplejson-3.8.2-py2.7.egg-info
```
so the `mv` command isn't needed.

The `bbappend` file can check for whether the extra-level exists and do nothing if it doesn't. That's what this fix does. I've run it in both if the situations above and the files end up in the correct place in both places.

It should do its rm command anyway.