### PR TITLE
Update and rename ffmpeg_3.2.2.bb to ffmpeg_3.2.4.bb

### DIFF
--- a/meta-oe/recipes-multimedia/ffmpeg/ffmpeg_3.2.4.bb
+++ b/meta-oe/recipes-multimedia/ffmpeg/ffmpeg_3.2.4.bb
@@ -16,8 +16,8 @@ LIC_FILES_CHKSUM = "file://COPYING.GPLv2;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
 SRC_URI = "https://www.ffmpeg.org/releases/${BP}.tar.xz \
            file://mips64_cpu_detection.patch \
           "
-SRC_URI[md5sum] = "e34d1b92c5d844f2a3611c741a6dba18"
-SRC_URI[sha256sum] = "3f01bd1fe1a17a277f8c84869e5d9192b4b978cb660872aa2b54c3cc8a2fedfc"
+SRC_URI[md5sum] = "39fd71024ac76ba35f04397021af5606"
+SRC_URI[sha256sum] = "6e38ff14f080c98b58cf5967573501b8cb586e3a173b591f3807d8f0660daf7a"
 
 # Build fails when thumb is enabled: https://bugzilla.yoctoproject.org/show_bug.cgi?id=7717
 ARM_INSTRUCTION_SET = "arm"


### PR DESCRIPTION
Eventuell sind via bbappend noch die folgenden Patche interessant?
https://github.com/samsamsam-iptvplayer/exteplayer3/blob/master/tmp/ffmpeg/patches/3.2.2/000001_add_dash_demux.patch
https://github.com/samsamsam-iptvplayer/exteplayer3/blob/master/tmp/ffmpeg/patches/3.2.2/000003_allow_to_choose_rtmp_impl_at_runtime.patch

Vielleicht guckt sich das jemand an.