### PR TITLE
Ignore certificate checking in the ffmpeg/Krypton download..

### DIFF
--- a/meta-oe/recipes-mediacenter/kodi/kodi/ffmpeg-autobuild.patch
+++ b/meta-oe/recipes-mediacenter/kodi/kodi/ffmpeg-autobuild.patch
@@ -1,0 +1,11 @@
+--- git/tools/depends/target/ffmpeg/autobuild.sh.orig	2017-05-01 17:26:31.943468428 +0100
++++ git/tools/depends/target/ffmpeg/autobuild.sh	2017-05-01 18:33:02.162813127 +0100
+@@ -116,7 +116,7 @@
+ fi
+ 
+ [ -f ${ARCHIVE} ] ||
+-  curl -Ls --create-dirs -f -o ${ARCHIVE} ${BASE_URL}/${VERSION}.tar.gz ||
++  curl -k -Ls --create-dirs -f -o ${ARCHIVE} ${BASE_URL}/${VERSION}.tar.gz ||
+   { echo "error fetching ${BASE_URL}/${VERSION}.tar.gz" ; exit 3; }
+ [ $downloadonly ] && exit 0
+ 

--- a/meta-oe/recipes-mediacenter/kodi/kodi_17.bb
+++ b/meta-oe/recipes-mediacenter/kodi/kodi_17.bb
@@ -87,6 +87,7 @@ SRC_URI = "git://github.com/xbmc/xbmc.git;branch=Krypton \
            file://v3d-platform.patch \
            file://brcmstb-settings.patch \
            file://e2player.patch \
+           file://ffmpeg-autobuild.patch \
 "
 
 SRC_URI_append_libc-musl = " \


### PR DESCRIPTION
..during the configure stage.
The OE-built curl doesn't have any certificates in place.