### PR TITLE
Kernel-Patch-Update  (more User-Ram)

### DIFF
--- a/meta-brands/meta-fulan/recipes-linux/linux-fulan/linux-sh4-spark7162_setup_stm24_0217.patch
+++ b/meta-brands/meta-fulan/recipes-linux/linux-fulan/linux-sh4-spark7162_setup_stm24_0217.patch
@@ -21,22 +21,22 @@
 +/*
 + 0x40000000 - 0x403FFFFF - cocpu 1 ram (4mb)
 + 0x40400000 - 0x407FFFFF - cocpu 2 ram (4mb)
-+ 0x40800000 - 0x47FFFFFF - linux   (120mb)
-+ 0x48000000 - 0x49FFFFFF - bigphys ( 32mb)
-+ 0x4A000000 - 0x4FFFFFFF - lmi_io  ( 96mb)
++ 0x40800000 - 0x498FFFFF - linux   (145mb)
++ 0x49900000 - 0x4B1FFFFF - bigphys ( 25mb)
++ 0x4B200000 - 0x4FFFFFFF - lmi_io  ( 78mb)
 + */
 + static struct bpa2_partition_desc bpa2_parts_table[] = {
 +     {
 +  	    .name  = "bigphysarea",
-+  	    .start = 0x48000000,
-+  	    .size  = 0x02000000, /* 32 Mb */
++	    .start = 0x49900000,
++	    .size  = 0x01900000, /* 25 Mb */
 +  	    .flags = 0,
 +  	    .aka   = NULL
 +     },
 +     {
 +  	    .name  = "LMI_IO",
-+  	    .start = 0x4A000000,
-+  	    .size  = 0x06000000, /* 92 Mb */
++  	    .start = 0x4B200000,
++  	    .size  = 0x04e00000, /* 78 Mb */
 +  	    .flags = 0,
 +  	    .aka   = LMI_IO_partalias
 +    },

--- a/meta-brands/meta-fulan/recipes-linux/linux-fulan/linux-sh4-spark_setup_stm24_0217.patch
+++ b/meta-brands/meta-fulan/recipes-linux/linux-fulan/linux-sh4-spark_setup_stm24_0217.patch
@@ -58,24 +58,24 @@
 +                                    "coredisplay-video", "gfx-memory", "BPA2_Region0", "LMI_VID", NULL };
 +
 +/*
-+0x40000000 - 0x403FFFFF - cocpu 1 ram (4mb)
-+0x40400000 - 0x407FFFFF - cocpu 2 ram (4mb)
-+0x40800000 - 0x47FFFFFF - linux   (120mb)
-+0x48000000 - 0x49FFFFFF - bigphys ( 32mb)
-+0x4A000000 - 0x4FFFFFFF - lmi_io  ( 96mb)
-+*/
-+static struct bpa2_partition_desc bpa2_parts_table[] = {
++ 0x40000000 - 0x403FFFFF - cocpu 1 ram (4mb)
++ 0x40400000 - 0x407FFFFF - cocpu 2 ram (4mb)
++ 0x40800000 - 0x498FFFFF - linux   (145mb)
++ 0x49900000 - 0x4B1FFFFF - bigphys ( 25mb)
++ 0x4B200000 - 0x4FFFFFFF - lmi_io  ( 78mb)
++ */
++ static struct bpa2_partition_desc bpa2_parts_table[] = {
 +    {
 + 	    .name  = "bigphysarea",
-+ 	    .start = 0x48000000,
-+ 	    .size  = 0x02000000, /* 32 Mb */
++	    .start = 0x49900000,
++	    .size  = 0x01900000, /* 25 Mb */
 + 	    .flags = 0,
 + 	    .aka   = NULL
 +    },
 +    {
 + 	    .name  = "LMI_IO",
-+ 	    .start = 0x4A000000,
-+ 	    .size  = 0x06000000, /* 96 Mb */
++  	    .start = 0x4B200000,
++  	    .size  = 0x04e00000, /* 78 Mb */
 + 	    .flags = 0,
 + 	    .aka   = LMI_IO_partalias
 +    },


### PR DESCRIPTION
https://www.opena.tv/edision-argus-pingulux/34291-ram-einstellungen-new-post.html

Wie hier angesprochen, den Patch mal umgebaut und etwa 25 mb mehr freien
Speicher für sh4 Boxen damit zur Verfügung gestellt.
GM-Triplex und 990 getestet und es ist noch immer Reserve da.
Eventuell sogar noch ein paar mehr mb möglich.