### PR TITLE
Update enigma2-plugin-drivers-dvb-usb-delock61959.bb

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-delock61959.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-delock61959.bb
@@ -1,27 +1,41 @@
-SUMMARY = "USB DVB driver for EM28xx chipset"
+SUMMARY = "USB DVB driver for Delock61959 USB DVB-C/T based on EM28xx chipset"
 inherit allarch
 
 require conf/license/license-gplv2.inc
 
 DVBPROVIDER ?= "kernel"
 
-SRC_URI = "file://delock61959_em28xx.conf"
-
 RRECOMMENDS_${PN} = " \
+${DVBPROVIDER}-module-em28xx \
 ${DVBPROVIDER}-module-em28xx-dvb \
-${DVBPROVIDER}-module-tda18271c2dd1 \
+${DVBPROVIDER}-module-em28xx-alsa \
+${DVBPROVIDER}-module-em28xx-rc \
+${DVBPROVIDER}-module-tda18271c2dd \
 ${DVBPROVIDER}-module-drxk \
-${DVBPROVIDER}-module-tuner \
-firmware-dvb-fe-drxk-delock \
+firmware-dvb-fe-drxk_a3 \
 "
 
 PV = "1.0"
 PR = "r1"
 
-
 PACKAGES = "${PN}"
-FILES_${PN} += "${sysconfdir}/modprobe.d"
 
-do_install() {
-  install -m 0644 delock61959_em28xx.conf ${D}/etc/modprobe.d/em28xx.conf
+pkg_postinst() {
+#!/bin/sh
+if [ -f ${D}/lib/firmware/dvb-demod-drxk-01.fw ]; then
+  rm ${D}/lib/firmware/dvb-demod-drxk-01.fw
+fi
+ln -s ${D}/lib/firmware/drxk_a3.mc ${D}/lib/firmware/dvb-demod-drxk-01.fw
+echo "options em28xx cards=89 usb_xfer_mode=0" > ${D}/etc/modprobe.d/em28xx.conf
+chmod 0644 ${D}/etc/modprobe.d/em28xx.conf
+}
+
+pkg_postrm() {
+#!/bin/sh
+if [ -f /lib/firmware/dvb-demod-drxk-01.fw ]; then
+  rm /lib/firmware/dvb-demod-drxk-01.fw
+fi
+if [ -f /etc/modprobe.d/em28xx.conf ]; then
+  rm /etc/modprobe.d/em28xx.conf
+fi
 }


### PR DESCRIPTION
EM28xx config is obsolete / options are not required necessarily (auto/default works) and can be created via echo during package postinstall. Same is for the different firmware : just the drxk_a3 firmware with different filename. Therefore : depend on drxk_a3 firmware and create symlink during package install.
Using correct modules everythings works fine out of the box using that device and the default kernel modules.