### PR TITLE
Delete em28xx.conf

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-dvb-drivers/files/delock61959_em28xx.conf
+++ b/meta-oe/recipes-oe-alliance/enigma2-dvb-drivers/files/delock61959_em28xx.conf
@@ -1,2 +1,0 @@
-options em28xx  disable_first_i2c_device=1
-options em28xx  disable_ir=1


### PR DESCRIPTION
File is obsolete. Driver options file is not required for correct function of module, and it may be created by a simple echo during package-postinstall of the driver package.