### PR TITLE
Fix recipes to allow softcams to pass QA.

### DIFF
--- a/meta-oe/recipes-connectivity/openssl/libcrypto-compat-0.9.7.bb
+++ b/meta-oe/recipes-connectivity/openssl/libcrypto-compat-0.9.7.bb
@@ -16,3 +16,7 @@ do_install () {
 }
 
 FILES_${PN} = "/usr/lib"
+
+# Set these explicitly
+#
+RPROVIDES_${PN} += "libcrypto.so.0.9.7 libssl.so.0.9.7"

--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-evocamd_2.17.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-evocamd_2.17.bb
@@ -4,6 +4,8 @@ require conf/license/license-close.inc
 
 PR = "r2"
 
+RDEPENDS_enigma2-plugin-softcams-evocamd = "libcrypto-compat-0.9.7"
+
 PACKAGES = "enigma2-plugin-softcams-evocamd"
 
 PROVIDES += "openvix-softcams-evocamd"

--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-newcs_1.67RC1.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-newcs_1.67RC1.bb
@@ -4,6 +4,8 @@ require conf/license/license-close.inc
 
 PR = "r2"
 
+RDEPENDS_enigma2-plugin-softcams-newcs = "libcrypto-compat-0.9.7"
+
 PACKAGES = "enigma2-plugin-softcams-newcs"
 
 PROVIDES += "openvix-softcams-newcs"

--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-scam_3.60a.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-scam_3.60a.bb
@@ -2,7 +2,7 @@ SUMMARY = "scam ${PV} softcam"
 LICENSE = "CLOSED"
 require conf/license/license-close.inc
 
-RDEPENDS_${PN} = "libcrypto-compat-0.9.7"
+RDEPENDS_enigma2-plugin-softcams-scam = "libcrypto-compat-0.9.7"
 
 PR = "r2"
 


### PR DESCRIPTION
It seems that in the softcam recipes `${PN}` isn't "correct" (== as expected) as `PACKAGES` is set, so the package name needs to be set explicitly (other softcam recipes use this).
And `libcrypto-compat-0.9.7` needs to set the `RPROVIDES` explicitly, otherwise QA fails for these 3 softcams.
This is when using the `nextp3` build environment.