### PR TITLE
Update dvbsnoop.bb

### DIFF
--- a/meta-oe/recipes-multimedia/dvbsnoop/dvbsnoop.bb
+++ b/meta-oe/recipes-multimedia/dvbsnoop/dvbsnoop.bb
@@ -7,11 +7,11 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 inherit gitpkgv
 
-SRCREV = "7763d9995c06dc1625ad7d873dde578a8c61d480"
+SRCREV = "c1ec72fc63339dc5fc38f6a912f21aa23a688511"
 PV = "1.4.53"
 PKGV = "1.4.53+git${GITPKGV}"
 
-SRC_URI = "git://github.com/persianpros/dvbsnoop.git;protocol=git"
+SRC_URI = "git://github.com/PLi-metas/dvbsnoop.git;protocol=git"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Switch to "PLi-metas" because future development will be there with the help of "Hains" and "MastaG".
persianpros URL will be available till March 2018 with no further development.
Also revision update for "[bskyb] fix Tag size limit"