### PR TITLE
nextp3 - readded libupnp 1.6, bumped samba to 4.7.6

### DIFF
--- a/meta-oe/conf/layer.conf
+++ b/meta-oe/conf/layer.conf
@@ -112,7 +112,7 @@ PREFERRED_PROVIDER_libusb-compat ?= "libusb-compat"
 PREFERRED_PROVIDER_directfb ?= "directfb"
 PREFERRED_PROVIDER_initd-functions = "lsbinitscripts"
 
-PREFERRED_VERSION_samba ?= "${@bb.utils.contains("MACHINE_FEATURES", "smallflash", "3.6.25", "4.7.5", d)}"
+PREFERRED_VERSION_samba ?= "${@bb.utils.contains("MACHINE_FEATURES", "smallflash", "3.6.25", "4.7.6", d)}"
 
 PREFERRED_VERSION_wpa-supplicant ?= "2.6"
 PREFERRED_VERSION_python-pygobject ?= "2.28.3"

--- a/meta-oe/recipes-connectivity/libupnp/libupnp1.6/sepbuildfix.patch
+++ b/meta-oe/recipes-connectivity/libupnp/libupnp1.6/sepbuildfix.patch
@@ -1,0 +1,34 @@
+From e198f0a87660a048164ca0e16d18517d0aee846e Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 9 Jun 2015 12:20:45 -0700
+Subject: [PATCH] Fix builds when using separate source and build directories.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ configure.ac           | 10 +++++-----
+ 1 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index a8731b5..54a3c3d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -744,9 +744,9 @@ AC_OUTPUT
+ #
+ # Files copied for windows compilation.
+ #
+-echo "configure: copying \"autoconfig.h\"          to \"build/inc/autoconfig.h\""
+-test -d build/inc || mkdir -p build/inc
+-cp autoconfig.h build/inc/autoconfig.h
+-echo "configure: copying \"upnp/inc/upnpconfig.h\" to \"build/inc/upnpconfig.h\""
+-cp upnp/inc/upnpconfig.h build/inc/upnpconfig.h
++echo "configure: copying \"autoconfig.h\"          to \"\$srcdir/build/inc/autoconfig.h\""
++test -d $srcdir/build/inc || mkdir -p $srcdir/build/inc
++cp autoconfig.h $srcdir/build/inc/autoconfig.h
++echo "configure: copying \"upnp/inc/upnpconfig.h\" to \"\$srcdir/build/inc/upnpconfig.h\""
++cp upnp/inc/upnpconfig.h $srcdir/build/inc/upnpconfig.h
+ 
+-- 
+1.9.1
+

--- a/meta-oe/recipes-connectivity/libupnp/libupnp1.6_1.6.21.bb
+++ b/meta-oe/recipes-connectivity/libupnp/libupnp1.6_1.6.21.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Portable SDK for UPnP* Devices"
+DESCRIPTION = "The Portable SDK for UPnP Devices is an SDK for development of \
+UPnP device and control point applications. It consists of the core UPnP \
+protocols along with a UPnP-specific eXtensible Markup Language (XML) parser \
+supporting the Document Object Model (DOM) Level 2 API and an optional, \
+integrated mini web server for serving UPnP related documents."
+HOMEPAGE = "http://pupnp.sourceforge.net/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b3190d5244e08e78e4c8ee78544f4863"
+
+SRC_URI = "${SOURCEFORGE_MIRROR}/pupnp/libupnp-${PV}.tar.bz2 \
+           file://sepbuildfix.patch \
+"
+
+SRC_URI[md5sum] = "513adadb07fa039a8aeb0ceb7b7b0f6e"
+SRC_URI[sha256sum] = "af3f3c0846a1d75baeadae4aa5a2bda427567e2a1fb4559bf73ccff0a4f9a39b"
+
+S = "${WORKDIR}/libupnp-${PV}"
+
+inherit autotools


### PR DESCRIPTION
please update openembedded modules first ...
whats in:

- libupnp - readded libupnp version 1.6, because it has been removed from openembedded but djmount and ushare wont compile with libupnp 1.8.x (only these two archaic apps use it, so maybe they should be  removed or replaced soon
- samba bumped to latest openembedded 4.7.6 version