### PR TITLE
meta-dinobot - try gcc8

### DIFF
--- a/meta-brands/meta-dinobot/recipes-linux/linux-dinobot-4.4.35/0002-log2-give-up-on-gcc-constant-optimizations.patch
+++ b/meta-brands/meta-dinobot/recipes-linux/linux-dinobot-4.4.35/0002-log2-give-up-on-gcc-constant-optimizations.patch
@@ -1,0 +1,85 @@
+From 0cb8a7b2037b36d178a63362d815ad9278ee7fff Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Sun, 29 Jul 2018 12:46:12 +0200
+Subject: [PATCH 2/5] log2 give up on gcc constant optimizations
+
+
+diff --git a/include/linux/log2.h b/include/linux/log2.h
+index fd7ff3d9..f38fae23 100644
+--- a/include/linux/log2.h
++++ b/include/linux/log2.h
+@@ -15,12 +15,6 @@
+ #include <linux/types.h>
+ #include <linux/bitops.h>
+ 
+-/*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+ /*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+@@ -85,7 +79,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -148,10 +142,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\
+diff --git a/tools/include/linux/log2.h b/tools/include/linux/log2.h
+index 41446668..d5677d39 100644
+--- a/tools/include/linux/log2.h
++++ b/tools/include/linux/log2.h
+@@ -12,12 +12,6 @@
+ #ifndef _TOOLS_LINUX_LOG2_H
+ #define _TOOLS_LINUX_LOG2_H
+ 
+-/*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+ /*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+@@ -78,7 +72,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -141,10 +135,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\
+-- 
+2.17.1
+

--- a/meta-brands/meta-dinobot/recipes-linux/linux-dinobot-4.4.35/0003-uaccess-dont-mark-register-as-const.patch
+++ b/meta-brands/meta-dinobot/recipes-linux/linux-dinobot-4.4.35/0003-uaccess-dont-mark-register-as-const.patch
@@ -1,0 +1,22 @@
+From 6157b5e4c1459bf18bd2aaad1219c1e3a49d8f58 Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Sun, 29 Jul 2018 12:52:47 +0200
+Subject: [PATCH 3/5] uaccess dont mark register as const
+
+
+diff --git a/arch/arm/include/asm/uaccess.h b/arch/arm/include/asm/uaccess.h
+index 7fb59199..7665bd2f 100644
+--- a/arch/arm/include/asm/uaccess.h
++++ b/arch/arm/include/asm/uaccess.h
+@@ -251,7 +251,7 @@ extern int __put_user_8(void *, unsigned long long);
+ 	({								\
+ 		unsigned long __limit = current_thread_info()->addr_limit - 1; \
+ 		const typeof(*(p)) __user *__tmp_p = (p);		\
+-		register const typeof(*(p)) __r2 asm("r2") = (x);	\
++		register typeof(*(p)) __r2 asm("r2") = (x);	\
+ 		register const typeof(*(p)) __user *__p asm("r0") = __tmp_p; \
+ 		register unsigned long __l asm("r1") = __limit;		\
+ 		register int __e asm("r0");				\
+-- 
+2.17.1
+

--- a/meta-brands/meta-dinobot/recipes-linux/linux-dinobot-4.4.35/0004-makefile-disable-warnings.patch
+++ b/meta-brands/meta-dinobot/recipes-linux/linux-dinobot-4.4.35/0004-makefile-disable-warnings.patch
@@ -1,0 +1,23 @@
+From ff63f0dc5acda48d21f9889ce8545d2119959101 Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Sun, 29 Jul 2018 14:45:50 +0200
+Subject: [PATCH 4/5] makefile disable warnings
+
+
+diff --git a/Makefile b/Makefile
+index ff936c88..8c8c252c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -619,6 +619,9 @@ include arch/$(SRCARCH)/Makefile
+ KBUILD_CFLAGS	+= $(call cc-option,-fno-delete-null-pointer-checks,)
+ KBUILD_CFLAGS	+= $(call cc-disable-warning,maybe-uninitialized,)
+ KBUILD_CFLAGS	+= $(call cc-disable-warning,frame-address,)
++KBUILD_CFLAGS	+= $(call cc-disable-warning,attribute-alias,)
++KBUILD_CFLAGS	+= $(call cc-disable-warning,stringop-truncation,)
++KBUILD_CFLAGS	+= $(call cc-disable-warning,format-truncation,)
+ 
+ ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
+ KBUILD_CFLAGS	+= -Os
+-- 
+2.17.1
+

--- a/meta-brands/meta-dinobot/recipes-linux/linux-dinobot-4.4.35/0005-kallsyms-allow-bigger-ksym_name_len.patch
+++ b/meta-brands/meta-dinobot/recipes-linux/linux-dinobot-4.4.35/0005-kallsyms-allow-bigger-ksym_name_len.patch
@@ -1,0 +1,22 @@
+From e81f2f8df5b357bd27ed37a4ce7a0a4d24726316 Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Sun, 29 Jul 2018 15:24:24 +0200
+Subject: [PATCH 5/5] kallsyms allow bigger KSYM_NAME_LEN
+
+
+diff --git a/scripts/kallsyms.c b/scripts/kallsyms.c
+index 8fa81e84..a6b98755 100644
+--- a/scripts/kallsyms.c
++++ b/scripts/kallsyms.c
+@@ -27,7 +27,7 @@
+ #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+ #endif
+ 
+-#define KSYM_NAME_LEN		128
++#define KSYM_NAME_LEN		256
+ 
+ struct sym_entry {
+ 	unsigned long long addr;
+-- 
+2.17.1
+

--- a/meta-brands/meta-dinobot/recipes-linux/linux-dinobot_4.4.35.bb
+++ b/meta-brands/meta-dinobot/recipes-linux/linux-dinobot_4.4.35.bb
@@ -20,11 +20,15 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/linux-${PV}/COPYING;md5=d7810fab7487fb0aad
 PKG_${KERNEL_PACKAGE_NAME}-base = "kernel-base"
 PKG_${KERNEL_PACKAGE_NAME}-image = "kernel-image"
 RPROVIDES_${KERNEL_PACKAGE_NAME}-base = "kernel-${KERNEL_VERSION}"
-RPROVIDES_kernel-image = "kernel-image-${KERNEL_VERSION}"
+RPROVIDES_${KERNEL_PACKAGE_NAME}-image = "kernel-image-${KERNEL_VERSION}"
 
 SRC_URI += "http://source.mynonpublic.com/dinobot/dinobot-linux-${PV}-${SRCDATE}.tar.gz \
     file://defconfig \
     file://sdio-platform.patch \
+    file://0002-log2-give-up-on-gcc-constant-optimizations.patch \
+    file://0003-uaccess-dont-mark-register-as-const.patch \
+    file://0004-makefile-disable-warnings.patch \
+    file://0005-kallsyms-allow-bigger-ksym_name_len.patch \
 "
 
 S = "${WORKDIR}/linux-${PV}"


### PR DESCRIPTION
- since hisi drivers are located in non standard kernel dir, it is better to silence warnings directly in makefile, because KERNEL_EXTRA_ARGS will not correctly handle the include path

- we also need to update meta-qt5 layer to sumo branch, else qtsensors or other qt pkgs may fail to build with segmentation fault error - this is caused by high number in BB_NUMBER_THREADS,so in normal setup it should be ok (with high number the memory overflow comed)