### PR TITLE
libxcrypt - add --disable-werror to configure

### DIFF
--- a/meta-oe/recipes-core/libxcrypt/libxcrypt_4.1.1.bbappend
+++ b/meta-oe/recipes-core/libxcrypt/libxcrypt_4.1.1.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--disable-werror"


### PR DESCRIPTION
else compile fail with inlining error from byteorder