### PR TITLE
try to fix 3rdparty plugins build

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-3rdparty-plugins.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-3rdparty-plugins.bb
@@ -146,8 +146,6 @@ do_install() {
     || true
 }
 
-do_package_write_ipk[noexec] = "1"
-
 python populate_packages_prepend () {
     pkg  = ""
     pkgs = ""
@@ -194,6 +192,10 @@ do_deploy() {
     if [ -e $pkgdir ]; then
         chmod 0755 $pkgdir
     fi
+}
+
+do_package_write_ipk() {
+    :
 }
 
 addtask do_deploy before do_package_write after do_package_write_ipk


### PR DESCRIPTION
- instead of pkg write ipk noexec use continue, this pevents no manifest created error
- locale archive creation from oe-core/meta/lib/oe/package_manager.py still remains (can be tweaked by changing "locale"to "localedir" on line 591