### PR TITLE
samba 3.6.25, pam-smbpass

### DIFF
--- a/meta-oe/recipes-connectivity/samba/samba36.inc
+++ b/meta-oe/recipes-connectivity/samba/samba36.inc
@@ -156,6 +156,8 @@ EXTRA_OECONF="--exec-prefix=/usr \
               vfsfileid_cv_statfs=yes \
 "
 
+PACKAGECONFIG[talloc] = "--enable-external-libtalloc --with-libtalloc, --disable-external-libtalloc --without-libtalloc, talloc"
+
 CFLAGS      += '-fPIC -DHAVE_IPV6=1 -DMAX_DEBUG_LEVEL=-1 -ffunction-sections -fdata-sections -ltalloc -I${STAGING_INCDIR}/tirpc'
 LDFLAGS     += "-Wl,--gc-sections -ltirpc"
 EXTRA_OEMAKE+= "DYNEXP= PICFLAG= MODULES="


### PR DESCRIPTION
- fixed undefined reference to _talloc... during recompile
- tested for mipsel, needs testing for other platforms