### PR TITLE
enigma2-locale:  chinese renamed in some distro

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2/enigma2-locale-meta.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2/enigma2-locale-meta.bb
@@ -46,6 +46,8 @@ RRECOMMENDS_${PN} = "\
     enigma2-locale-tr \
     enigma2-locale-uk \
     enigma2-locale-zh \
+    enigma2-locale-zh-cn \
+    enigma2-locale-zh-hk \
     ", d)}"
 
 PR = "r0"


### PR DESCRIPTION
for openpli and openatv new version, chinese locale renamed to zh_CN and zh_HK.

still need zh and hk for other distro.