### PR TITLE
try to fix openssl10 certs rehash problems

### DIFF
--- a/meta-oe/recipes-connectivity/openssl/openssl10_1.0.2%.bbappend
+++ b/meta-oe/recipes-connectivity/openssl/openssl10_1.0.2%.bbappend
@@ -16,3 +16,6 @@ RPROVIDES_${PN} ="openssl"
 
 PROVIDES += "libcrypto libssl openssl-conf openssl"
 
+openssl_package_preprocess () {
+    :
+}

--- a/meta-oe/recipes-support/ca-certificates/ca-certificates/use-c_rehash-openssl10.patch
+++ b/meta-oe/recipes-support/ca-certificates/ca-certificates/use-c_rehash-openssl10.patch
@@ -1,0 +1,16 @@
+diff --git a/sbin/update-ca-certificates b/sbin/update-ca-certificates
+index 16cb885..7e911a9 100755
+--- a/sbin/update-ca-certificates
++++ b/sbin/update-ca-certificates
+@@ -209,9 +209,9 @@ then
+   # only run if set of files has changed
+   if [ "$verbose" = 0 ]
+   then
+-    openssl rehash . > /dev/null
++    c_rehash . > /dev/null
+   else
+-    openssl rehash .
++    c_rehash .
+   fi
+ fi
+ 

--- a/meta-oe/recipes-support/ca-certificates/ca-certificates_%.bbappend
+++ b/meta-oe/recipes-support/ca-certificates/ca-certificates_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://use-c_rehash-openssl10.patch"


### PR DESCRIPTION
openssl10 - readd openssl bin and c_rehash script back to package
- only torso of openssl10 has been left in OE-core
ca-certificates - fix certs rehash at do_rootfs with openssl 1.0.2q
- use c_rehash instead of openssl rehash