### PR TITLE
[beyonwiz-hisi.inc] Correct "Beyonwiz" brand name

### DIFF
--- a/meta-brands/meta-beyonwiz/conf/machine/include/beyonwiz-hisi.inc
+++ b/meta-brands/meta-beyonwiz/conf/machine/include/beyonwiz-hisi.inc
@@ -9,7 +9,7 @@ IMAGEDIR = "beyonwiz/v2"
 
 MACHINE_NAME = "V2"
 
-MACHINE_BRAND = "BEYONWIZ"
+MACHINE_BRAND = "Beyonwiz"
 
 MTD_KERNEL = "mmcblk0p12"
 


### PR DESCRIPTION
Use mixed case for the "Beyonwiz" BRAND name.  Shouting is not necessary.  ;)

I would change the OEM name as well but I don't know if this has further implications.

Correction approved by Jai.
