### PR TITLE
[beyonwiz-hisi.inc] Correct "Beyonwiz" OEM name

### DIFF
--- a/meta-brands/meta-beyonwiz/conf/machine/include/beyonwiz-hisi.inc
+++ b/meta-brands/meta-beyonwiz/conf/machine/include/beyonwiz-hisi.inc
@@ -3,7 +3,7 @@ include conf/machine/include/build-extras.inc
 
 DISTRO_FEATURES_remove = "x11 wayland"
 
-BRAND_OEM = "beyonwiz"
+BRAND_OEM = "Beyonwiz"
 
 IMAGEDIR = "beyonwiz/v2"
 


### PR DESCRIPTION
Use mixed case for the "Beyonwiz" OEM name.

Correction approved by Jai.
