### PR TITLE
Remove bash extension from openvix-bootlogo.bb

### DIFF
--- a/meta-oe/recipes-distros/openvix/image/openvix-bootlogo.bb
+++ b/meta-oe/recipes-distros/openvix/image/openvix-bootlogo.bb
@@ -67,9 +67,9 @@ do_install_append_vuduo2() {
 inherit deploy
 do_deploy() {
     TEST=${MACHINEBUILD}
-    if [[ ${TEST:0:2} == "tm" ]]; then
+    if [ "$( echo $TEST | awk '{ string=substr($0, 1, 2); print string; }' )" = "tm" ]; then
         install -m 0644 tm-splash.bmp ${DEPLOYDIR}/${BOOTLOGO_FILENAME}
-    elif [[ ${TEST:0:2} == "iq" ]]; then
+    elif [ "$( echo $TEST | awk '{ string=substr($0, 1, 2); print string; }' )" = "iq" ]; then
         install -m 0644 iqon-splash.bmp ${DEPLOYDIR}/${BOOTLOGO_FILENAME}
     elif [ -e splash.bin ]; then
         install -m 0644 splash.bin ${DEPLOYDIR}/${BOOTLOGO_FILENAME}


### PR DESCRIPTION
Remove bash extension from openvix-bootlogo.bb (make it sh compatible). This will make it possible to build vuduo4k on Ubuntu with default shell. Recipe files should follow sh shell syntax. See chapter 8.2 Syntax of recipes, in OpenEmbedded User Manual.

Verification:
- Build of vuduo4k on Xubuntu 18.04 (with default shell)
- The part of the scripted that have been changed have been tested in an "#!/bin/sh" script file with various strings to check the if-statements.
