### PR TITLE
[bootlogo.sh] Add option for skin bootlogo

### DIFF
--- a/meta-oe/recipes-distros/beyonwiz/bootlogo/files/bootlogo.sh
+++ b/meta-oe/recipes-distros/beyonwiz/bootlogo/files/bootlogo.sh
@@ -5,6 +5,9 @@
 
 BOOTLOGO=/usr/share/bootlogo.mvi
 [ -f /etc/enigma2/bootlogo.mvi ] && BOOTLOGO=/etc/enigma2/bootlogo.mvi
+skin=`sed -En 's|config\.skin\.primary_skin=(.+)/skin\.xml|\1|p' /etc/enigma2/settings`
+[ -z $skin ] && skin=`strings -n 10 /usr/lib/enigma2/python/skin.pyo | egrep -o -m 1 ".+/skin.xml" | sed 's|/skin.xml.*||'`
+[ -n $skin  -a -f /usr/share/enigma2/$skin/bootlogo.mvi ] && BOOTLOGO=/usr/share/enigma2/$skin/bootlogo.mvi
 /usr/bin/showiframe ${BOOTLOGO}
 
 [ -f /etc/init.d/bootlogo.py ] && /usr/bin/python /etc/init.d/bootlogo.py


### PR DESCRIPTION
This change adds the option for skins to include a "bootlogo.mvi" image at the top level of the skin that will be used when that skin is selected.

The code first checks to see if a skin is defined in the "settings" file and uses it if found. If no skin is identified then the "skin.pyo" file is searched to see if a built-in skin has been defined. If found then that will be used. If no skin associated bootlogo is identified then the code will progress to the original search in "/etc/enigma2/" and finally use the image in "/usr/share/".
