### PR TITLE
Fix compile error ...

### DIFF
--- a/meta-oe/recipes-devtools/python/livestreamersrv_0.4.bb
+++ b/meta-oe/recipes-devtools/python/livestreamersrv_0.4.bb
@@ -7,7 +7,7 @@ inherit allarch
 LICENSE = "GPLv2+"
 require conf/license/license-gplv2.inc
 
-RDEPENDS_${PN} = "streamlink"
+RDEPENDS_${PN} = "streamlink python"
 
 SRC_URI = "git://github.com/athoik/livestreamersrv.git"
 S = "${WORKDIR}/git/"


### PR DESCRIPTION
Fix compile error ...

ERROR: livestreamersrv-0.4-r0 do_package_qa: QA Issue: /usr/sbin/livestreamersrv contained in package livestreamersrv requires /usr/bin/python2.7, but no providers found in RDEPENDS_livestreamersrv? [file-rdeps]
ERROR: livestreamersrv-0.4-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.