### PR TITLE
[qt] Fix Error Compile

### DIFF
--- a/meta-oe/recipes-qt/qt5/qtserialbus-git/0001-fix-compile-error.patch
+++ b/meta-oe/recipes-qt/qt5/qtserialbus-git/0001-fix-compile-error.patch
@@ -1,0 +1,15 @@
+From: RAED-Fairbird <rrrr53@hotmail.com>
+Date: Tue, 17 May 2016 13:52:16 +0200
+Subject: [PATCH] Fix error: 'SIOCGSTAMP' was not declared in this scope; did you mean 'SIOCSARP'
+
+diff --git a/src/plugins/canbus/socketcan/socketcanbackend.cpp b/src/plugins/canbus/socketcan/socketcanbackend.cpp
+--- a/src/plugins/canbus/socketcan/socketcanbackend.cpp
++++ b/src/plugins/canbus/socketcan/socketcanbackend.cpp
+@@ -49,6 +49,7 @@
+ #include <net/if.h>
+ #include <sys/ioctl.h>
+ #include <sys/time.h>
++#include <linux/sockios.h>
+ 
+ #ifndef CANFD_MTU
+ // CAN FD support was added by Linux kernel 3.6

--- a/meta-oe/recipes-qt/qt5/qtserialbus_git.bbappend
+++ b/meta-oe/recipes-qt/qt5/qtserialbus_git.bbappend
@@ -1,0 +1,8 @@
+# package is machine specific
+PACKAGE_ARCH := "${MACHINE_ARCH}"
+
+SRC_URI_append = "\
+           file://0001-fix-compile-error.patch \
+"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/qtserialbus-git:"


### PR DESCRIPTION
socketcanbackend.cpp: In member function ‘void SocketCanBackend::readSocket()’: socketcanbackend.cpp:697:41: error: ‘SIOCGSTAMP’ was not declared in this scope; did you mean ‘SIOCSARP’? 697 | if (Q_UNLIKELY(ioctl(canSocket, SIOCGSTAMP, &timeStamp) < 0)) {
      |                                         ^~~~~~~~~~
/home/jmp/rpmbuild/BUILD/qt-everywhere-src-5.13.0/qtbase/include/QtCore/../../src/corelib/global/qcompilerdetection.h:237:49: note: in definition of macro ‘Q_UNLIKELY’
  237 | #  define Q_UNLIKELY(expr)  __builtin_expect(!!(expr), false)
      |                                                 ^~~~
make: *** [Makefile:1217: .obj/socketcanbackend.o] Error 1