### PR TITLE
Removed sleep commands from preinst

### DIFF
--- a/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-glamouraurafhd-atv.bb
+++ b/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-glamouraurafhd-atv.bb
@@ -47,9 +47,6 @@ rm -rf /usr/lib/enigma2/python/Components/Renderer/Glam*
 echo "                                                                      "
 echo "Glamour Aura FHD ATV skin was successfully removed from your receiver."
 echo "                                                                      "
-echo "The GUI of your receiver is now rebooting....                         "
-sleep 2
-init 4 && sleep 2 && init 3
 }
 
 pkg_preinst_${PN} () {


### PR DESCRIPTION
Removed sleep commands from preinst to avoid possible enigma2 reboot during a sytem update process, that should interrupt correct installation it when my skin is updated!