### PR TITLE
Change back dependencies to recommendations (and fixed typo)

### DIFF
--- a/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-glamouraurafhd-atv.bb
+++ b/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-glamouraurafhd-atv.bb
@@ -10,7 +10,7 @@ PV = "14.x+git${SRCPV}"
 PKGV = "14.x+git${GITPKGV}"
 VER = "14.x"
 
-RRECOMENDS_${PN} = "enigma2-plugin-extensions-weathermsn enigma2-plugin-extensions-bitrate"
+RRECOMMENDS_${PN} = "enigma2-plugin-extensions-weathermsn enigma2-plugin-extensions-bitrate"
 
 SRC_URI = "git://github.com/MCelliotG/GlamourAuraFHD-ATV-skin.git;protocol=git"
 

--- a/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-glamouraurafhd-atv.bb
+++ b/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-glamouraurafhd-atv.bb
@@ -10,7 +10,7 @@ PV = "14.x+git${SRCPV}"
 PKGV = "14.x+git${GITPKGV}"
 VER = "14.x"
 
-RDEPENDS_${PN} = "enigma2-plugin-extensions-weathermsn enigma2-plugin-extensions-bitrate"
+RRECOMENDS_${PN} = "enigma2-plugin-extensions-weathermsn enigma2-plugin-extensions-bitrate"
 
 SRC_URI = "git://github.com/MCelliotG/GlamourAuraFHD-ATV-skin.git;protocol=git"
 


### PR DESCRIPTION
WeatherMSN and bitrate are not dependencies of the Aura skin to work. They need to be recommendations, because the skin can work fine without them. They are only recommended because they add extra features. This way the users can uninstall either package if they want to.