### PR TITLE
Switch minisatip to AUTOREV

### DIFF
--- a/meta-oe/recipes-extended/minisatip/minisatip.bb
+++ b/meta-oe/recipes-extended/minisatip/minisatip.bb
@@ -11,8 +11,8 @@ SRC_URI = " \
     file://minisatip.init \
     "
 
-SRCREV = "de38af408d8f511611f078ccc1ea40b43e8bf06a"
-UPSTREAMVERSION = "3.1d"
+SRCREV = "${AUTOREV}"
+UPSTREAMVERSION = "1.0d"
 PV = "${UPSTREAMVERSION}+git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Minisatip has some improvements in the last year:
-> support for pids=all
-> fix satip client
-> compatibility with newer oscam versions
-> improved compatibility with tuners
This switches minisatip from using a static sha to using the latest version