### PR TITLE
OE-A 4.4 OpenViX python 2/python 3 changes for ViX-Core

### DIFF
--- a/meta-oe/recipes-distros/openvix/image/openvix-base.bb
+++ b/meta-oe/recipes-distros/openvix/image/openvix-base.bb
@@ -23,6 +23,8 @@ RDEPENDS_${PN} = "\
     openvix-enigma2 \
     openvix-bootlogo \
     openvix-spinner \
+    python-future \
+    python-six \
     ${@bb.utils.contains("TUNE_FEATURES", "armv", "glibc-compat", "", d)} \
     python-service-identity \
     "

--- a/meta-oe/recipes-distros/openvix/image/openvix-core.bb
+++ b/meta-oe/recipes-distros/openvix/image/openvix-core.bb
@@ -3,8 +3,8 @@ MAINTAINER = "OpenViX"
 
 require conf/license/license-gplv2.inc
 
-DEPENDS = "enigma2 python-process libcrypto-compat-0.9.7 gettext-native"
-RDEPENDS_enigma2-plugin-vix-core = "ofgwrite python-process libcrypto-compat-0.9.7 python-compression zip procps python-beautifulsoup4 bzip2"
+DEPENDS = "enigma2 python-process libcrypto-compat-0.9.7 gettext-native python-future python-six "
+RDEPENDS_enigma2-plugin-vix-core = "ofgwrite python-process libcrypto-compat-0.9.7 python-compression zip procps python-beautifulsoup4 bzip2 python-future python-six"
 
 RCONFLICTS_enigma2-plugin-vix-core = "settings-autorestore"
 RREPLACES_enigma2-plugin-vix-core = "settings-autorestore"


### PR DESCRIPTION
Probably over kill, but allows ViX-core updated for Python 3 to run on both python 2 and python 3 builds 