### PR TITLE
OpenViX multiboot python2 -3 support. Boxbranding.so is not compatibl…

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2/enigma2.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2/enigma2.bb
@@ -30,6 +30,7 @@ RDEPENDS_${PN} = " \
     glibc-gconv-cp1250 \
     hotplug-e2-helper \
     ${PYTHON_RDEPS} \
+    ${@bb.utils.contains("DISTRO_NAME", "openvix", "image-identifier" , "", d)} \
     ${@bb.utils.contains("DISTRO_NAME", "openatv", "openatv-autorestore" , "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "uianimation", "vuplus-libgles-${MACHINE} libvugles2" , "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "hiaccel", "dinobot-libs-${MACHINE}" , "", d)} \

--- a/meta-oe/recipes-oe-alliance/enigma2/image-identifier.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2/image-identifier.bb
@@ -1,0 +1,38 @@
+SUMMARY = "Image identifier to help multiboot"
+SECTION = "base"
+PRIORITY = "required"
+LICENSE = "proprietary"
+MAINTAINER = "oe-alliance team"
+
+require conf/license/license-gplv2.inc
+
+PV = "${IMAGE_VERSION}"
+PR = "r${DATE}-${BUILD_VERSION}-${MACHINEBUILD}"
+PACKAGE_ARCH = "${MACHINEBUILD}"
+WORKDIR = "${TMPDIR}/work/${MULTIMACH_TARGET_SYS}/${PN}/${EXTENDPE}${PV}"
+do_configure[nostamp] = "1"
+
+S = "${WORKDIR}"
+
+PACKAGES = "${PN}"
+
+do_install() {
+    install -d ${D}/usr/lib/enigma2/python
+    printf "def getBoxType(): return '${MACHINEBUILD}'
+" > ${D}/usr/lib/enigma2/python/ImageIdentifier.py
+    printf "def getImageDistro(): return '${DISTRO_NAME}'
+" >> ${D}/usr/lib/enigma2/python/ImageIdentifier.py
+    printf "def getImageVersion(): return '${IMAGE_VERSION}'
+" >> ${D}/usr/lib/enigma2/python/ImageIdentifier.py
+    printf "def getImageBuild(): return '${BUILD_VERSION}'
+" >> ${D}/usr/lib/enigma2/python/ImageIdentifier.py
+    printf "def getImageDevBuild(): return '${DEVELOPER_BUILD_VERSION}'
+" >> ${D}/usr/lib/enigma2/python/ImageIdentifier.py
+    printf "def getImageType(): return '${DISTRO_TYPE}'
+" >> ${D}/usr/lib/enigma2/python/ImageIdentifier.py
+    printf "def getMachineBrand(): return '${MACHINE_BRAND}'
+" >> ${D}/usr/lib/enigma2/python/ImageIdentifier.py
+    printf "def getImageBuildDate(): return '${DATE}'
+" >> ${D}/usr/lib/enigma2/python/ImageIdentifier.py
+}
+FILES_${PN} += "/usr/lib/enigma2/python/ImageIdentifier.py"


### PR DESCRIPTION
…e between python 2 & 3, so this creates the Boxbranding support interface (thanks Huevos)