### PR TITLE
Support PYTHONEXTENSION for OpenATV

### DIFF
--- a/meta-oe/conf/distro/openatv.conf
+++ b/meta-oe/conf/distro/openatv.conf
@@ -18,6 +18,9 @@ E2DEFAULTSKIN = "enigma2-plugin-skins-metrix-atv"
 
 ENIGMA2_URI ?= "${@bb.utils.contains("DISTRO_TYPE", "release", "git://github.com/openatv/enigma2.git;protocol=git;branch=${DISTRO_VERSION}" , "git://github.com/openatv/enigma2.git;protocol=git;branch=DEV", d)}"
 
+PYTHONEXTENSION = "pyo"
+#PYTHONEXTENSION = "${@bb.utils.contains("DISTRO_VERSION", "6.4", "pyo", "py", d)}"
+
 IPKG_VARIANT = "opkg"
 
 FEED_NAME ?= "${DISTRO_NAME}-${DISTRO_VERSION}"

--- a/meta-oe/recipes-oe-alliance/enigma2/enigma2.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2/enigma2.bb
@@ -248,6 +248,8 @@ EXTRA_OECONF = " \
     ${@bb.utils.contains("MACHINE_FEATURES", "hiaccel", "--with-libhiaccel" , "", d)} \
     "
 
+EXTRA_OECONF_append_openatv = " --with-pyext=${PYTHONEXTENSION}"
+
 LDFLAGS_prepend = "${@bb.utils.contains('GST_VERSION', '1.0', ' -lxml2 ', '', d)}"
 SRC_URI_append = "${@bb.utils.contains("MACHINE_FEATURES", "uianimation", " file://use-lv3ddriver.patch" , "", d)}"
 


### PR DESCRIPTION
@jbleyel 

This is needed for https://github.com/openatv/enigma2/pull/1926

You could set PYTHONEXTENSION in a smart way or any way you think is better, I just write an example for 6.4 branch.

After adding this for all OE-A you could use it like what we do in Open Vision's OE:

do_install() {
    install -d ${D}${base_sbindir}
    install -m 755 ${S}/src/open_multiboot ${D}${base_sbindir}
    install -m 644 ${S}/contrib/open-multiboot-branding-helper.${PYTHONEXTENSION} ${D}${base_sbindir}
}

So many recipes could work for both python versions after this.

I'm not sure if this is ok but I tried to understand how OE-A is working as our OE is different.