### PR TITLE
[DM9X0] Fix compile error with Gcc 10.x

### DIFF
--- a/meta-brands/meta-dream/recipes-linux/linux-dreambox-3.14/make-yyloc-global-declaration-extern.patch
+++ b/meta-brands/meta-dream/recipes-linux/linux-dreambox-3.14/make-yyloc-global-declaration-extern.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/dtc/dtc-parser.tab.c_shipped b/scripts/dtc/dtc-parser.tab.c_shipped
+index ee1d8c3..a7be9f6 100644
+--- a/scripts/dtc/dtc-parser.tab.c_shipped
++++ b/scripts/dtc/dtc-parser.tab.c_shipped
+@@ -73,7 +73,7 @@
+ #include "dtc.h"
+ #include "srcpos.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+
+ extern int yylex(void);
+ extern void print_error(char const *fmt, ...);

--- a/meta-brands/meta-dream/recipes-linux/linux-dreambox_3.14.bb
+++ b/meta-brands/meta-dream/recipes-linux/linux-dreambox_3.14.bb
@@ -26,6 +26,7 @@ SRC_URI = " \
     file://0004-log2-give-up-on-gcc-constant-optimizations.patch \
     file://0005-uaccess-dont-mark-register-as-const.patch \
     file://0006-makefile-silence-packed-not-aligned-warn.patch \
+    file://make-yyloc-global-declaration-extern.patch \
 "
 
 SRC_URI[kernel.md5sum] = "b621207b3f6ecbb67db18b13258f8ea8"


### PR DESCRIPTION
scripts/dtc/dtc-parser.tab.o:(.bss+0x50): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here