### PR TITLE
tzdata: restore 32bit dates to zoneinfo files

### DIFF
--- a/meta-oe/recipes-extended/timezone/tzdata.bb
+++ b/meta-oe/recipes-extended/timezone/tzdata.bb
@@ -21,11 +21,11 @@ TZONES= "africa antarctica asia australasia europe northamerica southamerica  \
 
 do_compile () {
         for zone in ${TZONES}; do \
-            ${STAGING_BINDIR_NATIVE}/zic -d ${WORKDIR}${datadir}/zoneinfo -L /dev/null \
+            ${STAGING_BINDIR_NATIVE}/zic -b fat -d ${WORKDIR}${datadir}/zoneinfo -L /dev/null \
                 ${S}/${zone} ; \
-            ${STAGING_BINDIR_NATIVE}/zic -d ${WORKDIR}${datadir}/zoneinfo/posix -L /dev/null \
+            ${STAGING_BINDIR_NATIVE}/zic -b fat -d ${WORKDIR}${datadir}/zoneinfo/posix -L /dev/null \
                 ${S}/${zone} ; \
-            ${STAGING_BINDIR_NATIVE}/zic -d ${WORKDIR}${datadir}/zoneinfo/right -L ${S}/leapseconds \
+            ${STAGING_BINDIR_NATIVE}/zic -b fat -d ${WORKDIR}${datadir}/zoneinfo/right -L ${S}/leapseconds \
                 ${S}/${zone} ; \
         done
 }


### PR DESCRIPTION
As of the second half of last year the zic command defaults to its "slim" format which only has 64 bit date info. We need to switch back to the backwardly compatible "fat" format so the zoneinfo files can continue to work.

(See [iana's change log](https://ftp.iana.org/tz/tzdb-2020b/NEWS) and a similar discussion on this change at [pytz](https://github.com/stub42/pytz/issues/48))