### PR TITLE
[samba on jffs2] place lock dir in tmpfs

### DIFF
--- a/meta-oe/recipes-connectivity/samba/samba.bb
+++ b/meta-oe/recipes-connectivity/samba/samba.bb
@@ -78,7 +78,7 @@ EXTRA_OECONF += "--disable-cups \
                  --with-configdir=${sysconfdir}/samba \
                  --with-privatedir=${sysconfdir}/samba/private \
                  --with-piddir=${localstatedir}/run \
-                 --with-lockdir=${localstatedir}/lib/samba \
+                 --with-lockdir=${@bb.utils.contains('IMAGE_FSTYPES','jffs2','${localstatedir}/run/samba','${localstatedir}/lib/samba',d)} \
                  --with-cachedir=${localstatedir}/lib/samba \
                  --with-sockets-dir=${localstatedir}/run \
                  --with-logfilebase=${localstatedir}/log/samba \
@@ -193,6 +193,10 @@ do_install() {
     # fix file-rdeps qa warning
     if [ -f ${D}${bindir}/onnode ]; then
         sed -i 's:\(#!/bin/\)bash:\1sh:' ${D}${bindir}/onnode
+    fi
+
+    if ${@bb.utils.contains('IMAGE_FSTYPES','jffs2','true','false',d)}; then
+		rm -rf ${D}${localstatedir}/run/samba
     fi
 
     rm -rf ${D}/run ${D}${localstatedir}/run ${D}${localstatedir}/log


### PR DESCRIPTION
There's an incompatibility between Samba 4's database system and the jffs2 filesystem. 

Samba sometimes uses readwrite memory maps to access its tdb databases files. But this fails when the tdb files are stored on jffs2 volumes as jffs2 does not support readwrite memory maps. Trying to start samba with all the tdb files stored on jffs2 produces the following error:

```
[2021/06/08 22:12:01.076862,  0] ../source3/smbd/server.c:1754(main)
  smbd version 4.9.15 started.
  Copyright Andrew Tridgell and the Samba Team 1992-2018
[2021/06/08 22:12:01.307576,  0] ../lib/tdb_wrap/tdb_wrap.c:64(tdb_wrap_log)
  tdb(/var/lib/samba/smbXsrv_version_global.tdb): tdb_open_ex: tdb_new_database failed for /var/lib/samba/smbXsrv_version_global.tdb: Invalid argument
[2021/06/08 22:12:01.356210,  0] ../source3/smbd/smbXsrv_version.c:93(smbXsrv_version_global_init)
  smbXsrv_version_global_init: failed to open[/var/lib/samba/smbXsrv_version_global.tdb] - NT_STATUS_INVALID_PARAMETER
[2021/06/08 22:12:01.357408,  0] ../lib/util/become_daemon.c:122(exit_daemon)
  exit_daemon: daemon failed to start: Samba cannot init server context, error code 13
```

The solution is to place samba's lock files on tmpfs which does support readwrite memory maps.