### PR TITLE
[packagegroup-openplugins] Remove CrossEPG

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-plugins/packagegroup-openplugins.bbappend
+++ b/meta-oe/recipes-oe-alliance/enigma2-plugins/packagegroup-openplugins.bbappend
@@ -20,7 +20,6 @@ DEPENDS = " \
     enigma2-plugin-extensions-streaminterface \
     enigma2-plugin-extensions-telekomsport \
     enigma2-plugin-extensions-wakeonlan \
-    enigma2-plugin-systemplugins-crossepg \
     enigma2-plugin-extensions-setpicon \
     enigma2-plugin-extensions-xpower \
     enigma2-plugin-extensions-meteoviewer \


### PR DESCRIPTION
There are other better options, e.g.
- enigma2 built-in OpenTV download 
- OpenTV zapper plugin
- EPGRefresh
- EPGImport

Distros that want this plugin already have it in their feeds so no need to add it here, e.g.

- oe-alliance-core/meta-oe/recipes-distros/openatv/image/openatv-feeds.bb
- oe-alliance-core/meta-oe/recipes-distros/openbh/image/openbh-enigma2.bb
- oe-alliance-core/meta-oe/recipes-distros/openbh/image/openbh-feeds.bb
- oe-alliance-core/meta-oe/recipes-distros/opendroid/image/opendroid-feeds.bb
- oe-alliance-core/meta-oe/recipes-distros/openhdf/image/openhdf-feeds.bb
- oe-alliance-core/meta-oe/recipes-distros/openspa/image/openspa-feeds.bb