### PR TITLE
cleanup backport python problems

### DIFF
--- a/meta-oe/classes/python-backports-init.bbclass
+++ b/meta-oe/classes/python-backports-init.bbclass
@@ -1,0 +1,7 @@
+inherit python-dir
+
+RDEPENDS_${PN} += "python-backports-init"
+
+do_install_prepend() {
+    rm -rf $(find . -path "*/backports/__init__.py" -type f)
+}

--- a/meta-oe/recipes-devtools/python/python-backports-functools-lru-cache_1.5.bb
+++ b/meta-oe/recipes-devtools/python/python-backports-functools-lru-cache_1.5.bb
@@ -4,22 +4,27 @@ AUTHOR = "Jason R. Coombs <jaraco@jaraco.com>"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a33f38bbf47d48c70fe0d40e5f77498e"
 
+PYPI_PACKAGE = "backports.functools_lru_cache"
+
 DEPENDS = "python-setuptools-scm-native"
 
 RDEPENDS_${PN} += "\
+    ${PYTHON_PN}-pkgutil \
     ${PYTHON_PN}-pickle \
     ${PYTHON_PN}-threading \
     "
 
-SRC_URI = "https://files.pythonhosted.org/packages/57/d4/156eb5fbb08d2e85ab0a632e2bebdad355798dece07d4752f66a8d02d1ea/backports.functools_lru_cache-${PV}.tar.gz"
 SRC_URI[md5sum] = "20f53f54cd3f04b3346ce75a54959754"
 SRC_URI[sha256sum] = "9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a"
 
-S = "${WORKDIR}/backports.functools_lru_cache-${PV}"
 
-inherit setuptools
+inherit setuptools pypi python-backports-init
 
-do_install_append() {
-    # python-lzma already provides __init__.py(o) files
-    rm -rf ${D}${libdir}/${PYTHON_DIR}/site-packages/backports/__init__.py*
+do_install() {
+    install -d ${D}${PYTHON_SITEPACKAGES_DIR}/backports
+    install ${B}/backports/functools_lru_cache.py ${D}${PYTHON_SITEPACKAGES_DIR}/backports/
 }
+
+FILES_${PN} = "${PYTHON_SITEPACKAGES_DIR}/backports/functools_lru_cache.py"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-oe/recipes-devtools/python/python-backports-init/backports/__init__.py
+++ b/meta-oe/recipes-devtools/python/python-backports-init/backports/__init__.py
@@ -1,0 +1,5 @@
+# A Python "namespace package" http://www.python.org/dev/peps/pep-0382/
+# This always goes inside of a namespace package's __init__.py
+
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/meta-oe/recipes-devtools/python/python-backports-init_1.0.bb
+++ b/meta-oe/recipes-devtools/python/python-backports-init_1.0.bb
@@ -1,0 +1,27 @@
+SUMMARY = "Helper package to avoid backports/__init__.py conflicts"
+DETAIL = "backports packages in python2 suffer from a flaw in the namespace \
+implementation and can conflict with each other. For OE purposes, at least \
+fix the conflicting install of .../site-packages/backports/__init__.py"
+AUTHOR = "Tim Orling <ticotimo@gmail.com>"
+SECTION = "devel/python"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://backports/__init__.py"
+
+inherit python-dir
+
+# provide to avoid warnings
+do_compile() {
+    :
+}
+
+do_install() {
+    install -d ${D}${PYTHON_SITEPACKAGES_DIR}/backports
+    install ${WORKDIR}/backports/__init__.py ${D}${PYTHON_SITEPACKAGES_DIR}/backports/
+}
+
+FILES_${PN} = "${PYTHON_SITEPACKAGES_DIR}/backports/__init__.py"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-oe/recipes-devtools/python/python-backports-shutil-get-terminal-size_1.0.0.bb
+++ b/meta-oe/recipes-devtools/python/python-backports-shutil-get-terminal-size_1.0.0.bb
@@ -2,7 +2,7 @@ SUMMARY = "A backport of the get_terminal_size function from Python 3.3’s shut
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f3168ae4710d8f8c93f1b937983ae0dc"
 
-inherit pypi setuptools
+inherit pypi setuptools python-backports-init
 
 PYPI_PACKAGE = "backports.shutil_get_terminal_size"
 

--- a/meta-oe/recipes-devtools/python/python-backports-ssl_3.7.0.1.bb
+++ b/meta-oe/recipes-devtools/python/python-backports-ssl_3.7.0.1.bb
@@ -1,0 +1,19 @@
+SUMMARY = "The ssl.match_hostname() function from Python 3.4"
+DESCRIPTION = "The Secure Sockets layer is only actually secure if you check the hostname in the \
+certificate returned by the server to which you are connecting, and verify that it matches to hostname \
+that you are trying to reach. But the matching logic, defined in RFC2818, can be a bit tricky to implement \
+on your own. So the ssl package in the Standard Library of Python 3.2 and greater now includes a \
+match_hostname() function for performing this check instead of requiring every application to \
+implement the check separately. This backport brings match_hostname() to users of earlier versions of Python"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=b2adbe8bfdeb625c9a01afd9aaa66619"
+
+SRC_URI[md5sum] = "32d2f593af01a046bec3d2f5181a420a"
+SRC_URI[sha256sum] = "bb82e60f9fbf4c080eabd957c39f0641f0fc247d9a16e31e26d594d8f42b9fd2"
+
+PYPI_PACKAGE = "backports.ssl_match_hostname"
+
+inherit pypi setuptools python-backports-init
+
+RDEPENDS_${PN} += "${PYTHON_PN}-pkgutil"

--- a/meta-oe/recipes-devtools/python/python-websocket-client_0.59.0.bb
+++ b/meta-oe/recipes-devtools/python/python-websocket-client_0.59.0.bb
@@ -10,4 +10,5 @@ inherit pypi setuptools
 
 RDEPENDS_${PN} = "\
     ${PYTHON_PN}-six \
+    ${PYTHON_PN}-backports-ssl \
 "


### PR DESCRIPTION
add backport-init class from upstream
add python backoprt-init bb
fix backport-functools-lru-cache
add updated backports-ssl
fix backports-shutil-get-terminal-size with beackport init
Re-add depend backports-ssl->websocket-client