### PR TITLE
upx: Fix build with Ubuntu 21.10

### DIFF
--- a/meta-oe/recipes-core/upx/files/use-guard-clauses.patch
+++ b/meta-oe/recipes-core/upx/files/use-guard-clauses.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lzma-sdk/C/Common/MyCom.h b/src/lzma-sdk/C/Common/MyCom.h
+index b8dbf38..4cb299e 100644
+--- a/src/lzma-sdk/C/Common/MyCom.h
++++ b/src/lzma-sdk/C/Common/MyCom.h
+@@ -157,7 +157,7 @@ public:
+ #define MY_ADDREF_RELEASE \
+ STDMETHOD_(ULONG, AddRef)() { return ++__m_RefCount; } \
+ STDMETHOD_(ULONG, Release)() { if (--__m_RefCount != 0)  \
+-  return __m_RefCount; delete this; return 0; }
++  { return __m_RefCount; } delete this; return 0; }
+ 
+ #define MY_UNKNOWN_IMP_SPEC(i) \
+   MY_QUERYINTERFACE_BEGIN \

--- a/meta-oe/recipes-core/upx/upx_3.94.bb
+++ b/meta-oe/recipes-core/upx/upx_3.94.bb
@@ -7,6 +7,7 @@ SRC_URI = " \
     file://fix_indentation_for_gcc6.patch \
     file://whitespace.patch \
     file://void.patch \
+    file://use-guard-clauses.patch \
     "
 
 SRC_URI[md5sum] = "19e898edc41bde3f21e997d237156731"


### PR DESCRIPTION
Should not affect older versions of Ubuntu.

/../src/lzma-sdk/C/7zip/Compress/LZMA/../../../Common/MyCom.h:159:32:
error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
|   159 | STDMETHOD_(ULONG, Release)() { if (--__m_RefCount != 0)  \