### PR TITLE
Update 4.5.0

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-extensions-serienrecorder.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-extensions-serienrecorder.bb
@@ -12,7 +12,7 @@ RDEPENDS:${PN} = "${PYTHON_PN}-sqlite3 ${PYTHON_PN}-json ${PYTHON_PN}-xmlrpc ${P
 
 inherit gitpkgv allarch
 
-TAG = "v4.4.7"
+TAG = "v4.5.0"
 PV = "${TAG}"
 PKGV = "${TAG}"
 


### PR DESCRIPTION
Changelog Version 4.5.0
Neue Funktionen:
Beim TV-Planer Suchlauf wird jetzt eine Senderprüfung durchgeführt.
In der Serien-/Staffelstart Ansicht werden jetzt mit der blauen Taste die Serien für alle Sender geladen.
Neue Option „Backup-Dateien komprimieren“ zum Komprimieren der Backup-Dateien (siehe Anmerkungen 1)
Im openATV Image ab 7.1 gab es ein Problem mit der Darstellung der Picons im SerienRecorder (siehe Anmerkungen 2)
Wenn man die Staffel am Serien-Marker einschränkt, werden auf Wunsch auch automatisch die Timer-Liste bereinigt. (siehe Anmerkungen 3)
Wenn man in den globalen Einstellungen die Ansicht ohne zu speichern verlässt kommt jetzt eine Warnung
Neue Ansicht zum Wiederherstellen von gelöschten Einträgen aus der Timer-Liste. (siehe Anmerkungen 4)
n der Serien-Marker Ansicht kann man mit den Bouquet/Channel Tasten durch die Anfangsbuchstaben springen, also von A nach B nach C usw.


Änderungen:
An vielen Stellen wird jetzt statt der Wunschliste-ID die Fernsehserie-ID verwendet.
Beim manuellen Timer-Suchlauf werden jetzt auch vorher die Verzeichnisse geprüft.
Die Suchergebnisse werden jetzt auch farbig dargestellt (grün/rot), wenn für die Serie bereits ein Serien-Marker vorhanden ist.
Beim Timer-Suchlauf werden jetzt zusätzliche Informationen ausgegeben, die hoffentlich bei der Fehlersuche helfen (siehe Anmerkung 5)
Design der Sendetermine Ansicht geändert
Die Option in den Einstellungen "Manuelle Timer immer erstellen" wurde in "Manuelle Timer immer anlegen" umbenannt.
Farben für Serienname bzw. Episodenname verwendet wurden in allen Ansichten angeglichen.
Titel in der Top 30 Ansicht hinzugefügt: Die Serien mit den meisten Abrufen in den letzten 12 Monaten
Die Senderzuordnung wurde überarbeitet, sodass jetzt (fast) überall im SerienRecorder die ServiceRef verwendet wird. (siehe Anmerkungen 6)
Konfliktbehandlung von Timern korrigiert (siehe Anmerkung 7)
Prüfung auf Änderungen an der Senderliste in der Senderzuordnung (Taste 8) eingefügt (siehe Anmerkung 8)
Setzen/Ändern der TVDB-ID komplett überarbeitet (siehe Anmerkung 9)
Verhalten der Changelog Ansicht beim Start des SerienRecorders verbessert.


Bugfixes:
In seltenen Fällen konnte es vorkommen, dass zwar ein Timer angelegt wurde, aber kein Eintrag in die Timer-Liste erfolgte.
Absturz beim Timer-Suchlauf, wenn die TV-Planer E-Mail aktiviert war und der SerienServer nicht erreichbar war.
Anpassungen für openATV 7.1 - es gab Probleme bei der Verarbeitung der TV-Planer E-Mail.
Wenn man zwischen der Serien-Planer und der Top 30 Ansicht wechselt wird die Selektion zurückgesetzt.
Fehler beim Hinzufügen von Einträgen in die Timer-Liste korrigiert (Episodenliste und Timer-Liste).
Keine Bootschleife mehr wenn das Webinterface komplett entfernt wurde, aber das SerienRecorder Webinterface noch aktiviert ist.
Anlegen von manuellen Timern aus dem SerienRecorder Webinterface funktioniert jetzt wieder korrekt.
Tags werden jetzt anders in der Datenbank gespeichert um mit Python 3 kompatibel zu sein.
Beim Speichern der Serien-Marker Einstellungen über das Webinterface gehen die Tags nicht mehr kaputt.


Anmerkungen:
Wenn die Option "Backup-Dateien komprimieren“ aktiv ist, wird ein .tar.gz von den Dateien aus dem Backup gemacht,
dabei wird auch die Verzeichnisstruktur beibehalten, sodass man das Backup leichter wieder zurückspielen kann.
Ein weiterer Vorteil ist, dass die Backups so deutlich kleiner sind, bei mir 250 kB zu 980 kB.
Zu beachten ist, dass wenn man die Komprimierung aktiviert, nur noch diese Dateien automatisch nach x Tagen gelöscht werden,
nicht aber die Ordner die bisher angelegt wurden, man muss diese also von Hand löschen.
Das gilt natürlich auch im umgekehrten Fall, wenn die Komprimierung irgendwann wieder deaktiviert wird.
Wenn man Picons mit Sendernamen verwendet, musste die Picon Datei bisher genauso heißen wie der Sender.
Jetzt wird die Datei zusätzlich mit einem normierten Norm gesucht.
Alle Leerzeichen im Sendernamen werden entfernt und er wird in Kleinbuchstaben umgewandelt.
Aus "Das Erste" wird also "daserste". So werden die Picons zuverlässiger gefunden, weil beide Varianten gesucht werden.
Außerdem wird das Default Picon jetzt korrekt geladen, wenn kein Picon für den Sender gefunden wurde.
Das Default Picon stammt aus dem Image Skin: /usr/share/enigma2/skin_default/picon_default.png.
Timer-Liste bei Staffeleinschränkung funktioniert, wenn man am Serien-Marker eine "ab Staffel" aktiviert hat.
Wenn man z.B. "ab Staffel 3" eingestellt hat und die Auswahl verlässt, fragt der SerienRecorder:
"Sollen die Timer Einträge für ältere Staffeln aus der Datenbank gelöscht werden?"
Bei "Ja" werden dann automatisch alle Timer-Einträge für die Staffeln 2, 1 und 0 sowie "Specials" dieser Serie gelöscht.
Im Anschluss wird angezeigt, wie viele Einträge gelöscht wurden.
Wenn man zusätzlich noch andere Staffeln gewählt hat, z.B. "Staffel 1" und "ab Staffel 3" würden 2, 0 und Specials gelöscht.
Falls "Specials" aktiviert waren, bleiben die natürlich erhalten.
Wird Staffel 0 gewählt, werden bei Bedarf die Einträge bis zur gewählten Episode aus der Timer-Liste gelöscht.
Wiederherstellen gelöschter Timer-Eintrage lässt sich der Timer-Liste aufrufen:
Timer-Liste (blaue Taste) -> Timer-Liste bearbeiten (OK) -> Wiederherstellen (blaue Taste).
Dort hat man dann vier Funktionen: "Eintrag endgültig löschen" (rote Taste), "Eintrag wiederherstellen" (grüne Taste),
"Alle Einträge des ausgewählten Tages wiederherstellen" (gelbe Taste) und
"Alle Einträge der ausgewählten Serie wiederherstellen" (blaue Taste)
Es wird geprüft, ob der in der E-Mail angegebene Sender auch im SerienRecorder zugeordnet ist.
Falls nicht, wird eine entsprechende Meldung im Log ausgegeben.
Der Sender ' xyz ' wurde in der TV-Planer E-Mail gefunden, ist aber im SerienRecorder nicht zugeordnet.
' xyz ' - Für diesen Serien-Marker sind die Staffeln eingeschränkt - es werden nicht alle Ausstrahlungstermine berücksichtigt.
' xyz ' - Für diesen Serien-Marker sind die Sender eingeschränkt - es werden nicht alle Ausstrahlungstermine berücksichtigt.
Es wurden ' 194 ' Ausstrahlungstermine für ' 41 ' Serien vom SerienServer abgerufen.
Berücksichtigt werden ' 143 ' Ausstrahlungstermine für ' 35 ' Serien.
Dazu passend auch die Ausgabe, wenn man den TV-Planer Suchlauf nutzt:
Es wurden ' 34 ' Ausstrahlungstermine für ' 10 ' Serien aus der TV-Planer E-Mail ausgelesen.
Berücksichtigt werden ' 24 ' Ausstrahlungstermine für ' 9 ' Serien.
Bisher wurden bei der Senderzuordnung im SerienRecorder neben der ServiceRef auch der Sendername in der Datenbank gespeichert.
Hat sich der Sendername oder die ServiceRef auf der Box verändert, dann hat der SerienRecorder Probleme bekommen.
Durch die Änderungen in dieser Version wird der Sendername für die Anzeige live aus der Senderliste der Box ermittelt.
So sieht man auch in der Senderzuordnung wenn ein falscher Sender durch eine Änderung der ServiceRef vorhanden ist.
Das Webinterface ist an dieser Stelle noch nicht komplett umgestellt.
Offenbar gab es schon ziemlich lange ein Problem beim Timer-Suchlauf, wenn dabei ein Timerkonflikt auftrat.
Dann hätte eigentlich ein deaktivierter Timer sowie ein Eintrag in die Timerkonflikt-Liste im SerienRecorder erstellt werden sollen.
Das hat aber offenbar nur manchmal funktioniert und der deaktivierte Timer wurde mit falschen Vor- und Nachlaufzeiten angelegt.
Ich habe jetzt die Erstellung von deaktivierten Timern, im Falle eines Konfliktes, komplett überarbeitet.
Es gab schon seit einiger Zeit die Möglichkeit mit der Taste 8 in der Senderzuordnung eine Prüfung der Sender durchzuführen.
Dabei wurde bisher aber nur geprüft, ob die im SerienRecorder zugewiesenen Sender noch in der Senderliste der Box vorhanden waren.
Mit diesem Update habe ich die Funktion erweitert, sodass jetzt auch Namensänderungen und Umzüge von Sendern erkannt werden.
Änderung bei der Eingabe der TVDB-ID (für diejenigen die die Berechtigung haben).
Bisher konnte man die TVDB-ID im SerienRecorder nur händisch eingeben,
man musste also zunächst im Webbrowser die TVDB-ID ermitteln und sie dann eingeben.
Jetzt kann der SerienRecorder auch bei TheTVDB nach dem Namen der Serie suchen und die TVDB-ID kann bequem ausgewählt werden.