### PR TITLE
Fixes to IceTV plugin recipe

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-systemplugins-icetv.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-systemplugins-icetv.bb
@@ -1,15 +1,17 @@
+# Gets the package version from the most recent tag in the package repository
+
 SUMMARY = "IceTV EPG & recording management service"
 DESCRIPTION = "IceTV provides an online subscription service for EPG and recording management in Australia."
-MAINTAINER = "prl"
+MAINTAINER = "prl <prl@ozemail.com.au>"
 LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://IceTV/src/LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+LIC_FILES_CHKSUM = "file://icetv/src/LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 require conf/python/python3-compileall.inc
 
 inherit autotools-brokensep gettext gitpkgv ${PYTHON_PN}native ${PYTHON_PN}targetconfig
 
 SRCREV = "${AUTOREV}"
-PV = "20221016+git${SRCPV}"
-PKGV = "20221016+git${GITPKGV}"
+PV = "git${SRCPV}"
+PKGV = "${GITPKGVTAG}"
 
 SRC_URI = "git://bitbucket.org/prl/icetv.git;protocol=https;branch=master"
 
@@ -22,5 +24,47 @@ FILES:${PN}-meta = "${datadir}/meta"
 
 python populate_packages:prepend() {
     enigma2_plugindir = bb.data.expand('${libdir}/enigma2/python/Plugins', d)
-    do_split_packages(d, enigma2_plugindir, '^(\w+/\w+)/.*\/.*\.po$', 'enigma2-plugin-%s-po', '%s (translations)', recursive=True, match_path=True, prepend=True)
+
+    def getControlLines(mydir, d, package):
+        packagename = package[-1]
+        import os
+        try:
+            src = open(mydir + packagename + "/CONTROL/control").read()
+        except IOError:
+            return
+        for line in src.split("\n"):
+            full_package = package[0] + '-' + package[1] + '-' + package[2] + '-' + package[3]
+            if line.startswith('Depends: '):
+                # some plugins still reference twisted-* dependencies, these packages are now called ${PYTHON_PN}-twisted-*
+                rdepends = []
+                for depend in line[9:].split(','):
+                    depend = depend.strip()
+                    if depend.startswith('twisted-'):
+                        rdepends.append(depend.replace('twisted-', '${PYTHON_PN}-twisted-'))
+                    elif depend == 'python-re' or depend == 'python-lang' or depend == 'python-textutils':
+                        pass
+                    elif depend.startswith('python-'):
+                        rdepends.append(depend.replace('python-', '${PYTHON_PN}-'))
+                    elif depend.startswith('gst-plugins-'):
+                        rdepends.append(depend.replace('gst-plugins-', 'gstreamer1.0-'))
+                    elif depend.startswith('enigma2') and not depend.startswith('enigma2-'):
+                        pass # Ignore silly depends on enigma2 with all kinds of misspellings
+                    else:
+                        rdepends.append(depend)
+                rdepends = ' '.join(rdepends)
+                d.setVar('RDEPENDS:' + full_package, rdepends)
+            elif line.startswith('Recommends: '):
+                d.setVar('RRECOMMENDS:' + full_package, line[12:])
+            elif line.startswith('Description: '):
+                d.setVar('DESCRIPTION:' + full_package, line[13:])
+            elif line.startswith('Replaces: '):
+                d.setVar('RREPLACES:' + full_package, ' '.join(line[10:].split(', ')))
+            elif line.startswith('Conflicts: '):
+                d.setVar('RCONFLICTS:' + full_package, ' '.join(line[11:].split(', ')))
+            elif line.startswith('Maintainer: '):
+                d.setVar('MAINTAINER_' + full_package, line[12:])
+
+    mydir = d.getVar('D', True) + "/../git/"
+    for package in d.getVar('PACKAGES', d, 1).split():
+        getControlLines(mydir, d, package.split('-'))
 }


### PR DESCRIPTION
Add comment indicating how the package version number is derived.

Add an email address to the maintainer.

Update LIC_FILES_CHKSUM to reflect the new structure of the IceTV plugin source.

A more standars versioning for the package, and fetch the package version from the latest tag in the package repository.

Remove redundant do_split_packages() call.

Update recipe variables from the package repository CONTROL/control file so that recommended packages are built and information from the repository control file is passed to the package control file. Mechanism copied from theenigma2-plugins.bb recipe.