### PR TITLE
Fixed zerotier branch master to main

### DIFF
--- a/meta-oe/recipes-connectivity/zerotier/zerotier_1.10.2.bb
+++ b/meta-oe/recipes-connectivity/zerotier/zerotier_1.10.2.bb
@@ -16,7 +16,7 @@ SRCREV = "${AUTOREV}"
 PV = "1.10.2+git${SRCPV}"
 PKGV = "1.10.2+git${GITPKGV}"
 
-SRC_URI = "git://github.com/zerotier/ZeroTierOne.git;protocol=https;branch=master \
+SRC_URI = "git://github.com/zerotier/ZeroTierOne.git;protocol=https;branch=main \
         file://zerotier \
         file://0001-accept-external-ldflags.patch \
         file://0003-dont-enable-AES-hwcaps-for-arm.patch \


### PR DESCRIPTION
bb.data_smart.ExpansionError: Failure expanding variable SRCPV, expression was ${@bb.fetch2.get_srcrev(d)} which triggered exception FetchError: Fetcher failure: Unable to resolve 'master' in upstream git repository in git ls-remote output for github.com/zerotier/ZeroTierOne.git