### PR TITLE
libdvbcsa: Switch to oe-mirror

### DIFF
--- a/meta-oe/recipes-multimedia/libdvbcsa/libdvbcsa_git.bb
+++ b/meta-oe/recipes-multimedia/libdvbcsa/libdvbcsa_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Open implementation of the DVB Common Scrambling Algorithm, encrypt and decrypt "
 SECTION = "libs/multimedia"
-LICENSE = "LGPL-2.1-or-later"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 inherit gitpkgv
@@ -9,13 +9,15 @@ SRCREV = "${AUTOREV}"
 PV = "1.1.0+git"
 PKGV = "1.1.0+git${GITPKGV}"
 
-SRC_URI = "git://code.videolan.org/videolan/libdvbcsa.git;protocol=https;branch=master \
+SRC_URI = "git://github.com/oe-mirrors/libdvbcsa.git;protocol=https;branch=master \
            file://libdvbcsa.pc \
 "
 
 S = "${WORKDIR}/git"
 
 inherit autotools lib_package pkgconfig
+
+EXTRA_OECONF += "${@bb.utils.contains("TUNE_FEATURES", "neon", "--enable-neon", "--enable-uint32", d)}"
 
 do_install:append() {
     install -d ${D}${includedir}/dvbcsa/


### PR DESCRIPTION
- use patched libdvbcsa to support ecm processing
- add basic optimization for neon capabale cpus