### PR TITLE
vix oscam - use Hains repository

### DIFF
--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-latest-arm.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-latest-arm.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 PV = "1.30+git"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://repo.or.cz/oscam.git;protocol=git"
+SRC_URI = "git://repo.or.cz/oscam.git;protocol=git;branch=master"
 
 PACKAGES = "enigma2-plugin-softcams-oscam-pcscd-latest"
 

--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-latest-arm.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-latest-arm.bb
@@ -1,13 +1,14 @@
 require conf/license/license-gplv2.inc
 inherit cmake
+inherit gitpkgv
 
 SUMMARY = "OScam ${PV} Open Source Softcam, with OMNIKEY support."
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-PV = "1.20+svn"
+PV = "1.30+git"
 SRCREV = "${AUTOREV}"
-SRC_URI = "svn://svn.streamboard.tv/oscam;protocol=https;module=trunk;scmdata=keep;externals=nowarn"
+SRC_URI = "git://repo.or.cz/oscam.git;protocol=git"
 
 PACKAGES = "enigma2-plugin-softcams-oscam-pcscd-latest"
 
@@ -17,7 +18,7 @@ RPROVIDES:enigma2-plugin-softcams-oscam-pcscd-latest += "openvix-softcams-oscam-
 DEPENDS = "libusb openssl pcsc-lite"
 RDEPENDS:enigma2-plugin-softcams-oscam-pcscd-latest = "pcsc-lite"
 
-S = "${WORKDIR}/trunk"
+S = "${WORKDIR}/git"
 
 EXTRA_OECMAKE += "\
     -DOSCAM_SYSTEM_NAME=FriendlyARM \

--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-latest-mipsel.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-latest-mipsel.bb
@@ -1,13 +1,14 @@
 require conf/license/license-gplv2.inc
 inherit cmake
+inherit gitpkgv
 
 SUMMARY = "OScam ${PV} Open Source Softcam, with OMNIKEY support."
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-PV = "1.20+svn"
+PV = "1.30+git"
 SRCREV = "${AUTOREV}"
-SRC_URI = "svn://svn.streamboard.tv/oscam;protocol=https;module=trunk;scmdata=keep;externals=nowarn"
+SRC_URI = "git://repo.or.cz/oscam.git;protocol=git"
 
 PACKAGES = "enigma2-plugin-softcams-oscam-pcscd-latest"
 
@@ -17,7 +18,7 @@ RPROVIDES:enigma2-plugin-softcams-oscam-pcscd-latest += "openvix-softcams-oscam-
 DEPENDS = "libusb openssl pcsc-lite"
 RDEPENDS:enigma2-plugin-softcams-oscam-pcscd-latest = "pcsc-lite"
 
-S = "${WORKDIR}/trunk"
+S = "${WORKDIR}/git"
 
 EXTRA_OECMAKE += "\
     -DOSCAM_SYSTEM_NAME=Tuxbox \

--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-latest-mipsel.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-latest-mipsel.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 PV = "1.30+git"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://repo.or.cz/oscam.git;protocol=git"
+SRC_URI = "git://repo.or.cz/oscam.git;protocol=git;branch=master"
 
 PACKAGES = "enigma2-plugin-softcams-oscam-pcscd-latest"
 

--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-mipsel.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-mipsel.bb
@@ -11,7 +11,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/openvix-softcams-oscam:"
 PV = "1.20+11517"
 SRCREV = "a2ee0528f1de527748aaf7a79982ed112ffa3183"
 
-SRC_URI = "git://repo.or.cz/oscam.git;protocol=git"
+SRC_URI = "git://repo.or.cz/oscam.git;protocol=git;branch=master"
 
 PR = "r1"
 

--- a/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-mipsel.bb
+++ b/meta-oe/recipes-distros/openvix/softcams/openvix-softcams-oscam-pcscd-mipsel.bb
@@ -1,5 +1,6 @@
 require conf/license/license-gplv2.inc
 inherit cmake
+inherit gitpkgv
 
 SUMMARY = "OScam ${PV} Open Source Softcam, with OMNIKEY support."
 LICENSE = "GPL-3.0-only"
@@ -7,9 +8,10 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/openvix-softcams-oscam:"
 
-PV = "1.20+svn"
-SRCREV = "11517"
-SRC_URI = "svn://svn.streamboard.tv/oscam;protocol=https;module=trunk;scmdata=keep;rev=${SRCREV};externals=nowarn"
+PV = "1.20+11517"
+SRCREV = "a2ee0528f1de527748aaf7a79982ed112ffa3183"
+
+SRC_URI = "git://repo.or.cz/oscam.git;protocol=git"
 
 PR = "r1"
 
@@ -21,7 +23,7 @@ RPROVIDES:enigma2-plugin-softcams-oscam-pcscd += "openvix-softcams-oscam-pcscd-m
 DEPENDS = "libusb openssl pcsc-lite"
 RDEPENDS:enigma2-plugin-softcams-oscam-pcscd = "pcsc-lite"
 
-S = "${WORKDIR}/trunk"
+S = "${WORKDIR}/git"
 
 EXTRA_OECMAKE += "\
     -DOSCAM_SYSTEM_NAME=Tuxbox \

--- a/meta-oe/recipes-distros/openvix/softcams/oscam-latest.inc
+++ b/meta-oe/recipes-distros/openvix/softcams/oscam-latest.inc
@@ -9,4 +9,4 @@ RPROVIDES:${PN} += "enigma2-plugin-softcams-oscam-openvix"
 RREPLACES:${PN} += "enigma2-plugin-softcams-oscam-openvix"
 RCONFLICTS:${PN} += "enigma2-plugin-softcams-oscam-openvix"
 
-SRC_URI += "svn://svn.streamboard.tv/oscam;protocol=https;module=trunk;scmdata=keep"
+SRC_URI += "git://repo.or.cz/oscam.git;protocol=git"

--- a/meta-oe/recipes-distros/openvix/softcams/oscam-latest.inc
+++ b/meta-oe/recipes-distros/openvix/softcams/oscam-latest.inc
@@ -9,4 +9,4 @@ RPROVIDES:${PN} += "enigma2-plugin-softcams-oscam-openvix"
 RREPLACES:${PN} += "enigma2-plugin-softcams-oscam-openvix"
 RCONFLICTS:${PN} += "enigma2-plugin-softcams-oscam-openvix"
 
-SRC_URI += "git://repo.or.cz/oscam.git;protocol=git"
+SRC_URI += "git://repo.or.cz/oscam.git;protocol=git;branch=master"

--- a/meta-oe/recipes-distros/openvix/softcams/oscam-stable.inc
+++ b/meta-oe/recipes-distros/openvix/softcams/oscam-stable.inc
@@ -5,5 +5,5 @@ CAMNAME = "oscam-stable"
 SUMMARY:${PN} = "OSCam-stable ${PKGV}"
 DESCRIPTION:${PN} = "OSCam Open Source Softcam\n \
 - build from a known stable trunk revision\n \"
-SRC_URI += "git://repo.or.cz/oscam.git;protocol=git;branch=master;rev=${SRCREV}"
+SRC_URI += "git://repo.or.cz/oscam.git;protocol=git;branch=master"
 PR = "r2"

--- a/meta-oe/recipes-distros/openvix/softcams/oscam-stable.inc
+++ b/meta-oe/recipes-distros/openvix/softcams/oscam-stable.inc
@@ -1,7 +1,9 @@
-SRCREV = "11581"
+PV = "1.20+11581"
+SRCREV = "e4c5382da03fdef06d308a4844c5598e6330c03e"
+
 CAMNAME = "oscam-stable"
 SUMMARY:${PN} = "OSCam-stable ${PKGV}"
 DESCRIPTION:${PN} = "OSCam Open Source Softcam\n \
 - build from a known stable trunk revision\n \"
-SRC_URI += "svn://svn.streamboard.tv/oscam;protocol=https;module=trunk;scmdata=keep;rev=${SRCREV}"
+SRC_URI += "git://repo.or.cz/oscam.git;protocol=git;rev=${SRCREV}"
 PR = "r2"

--- a/meta-oe/recipes-distros/openvix/softcams/oscam-stable.inc
+++ b/meta-oe/recipes-distros/openvix/softcams/oscam-stable.inc
@@ -5,5 +5,5 @@ CAMNAME = "oscam-stable"
 SUMMARY:${PN} = "OSCam-stable ${PKGV}"
 DESCRIPTION:${PN} = "OSCam Open Source Softcam\n \
 - build from a known stable trunk revision\n \"
-SRC_URI += "git://repo.or.cz/oscam.git;protocol=git;rev=${SRCREV}"
+SRC_URI += "git://repo.or.cz/oscam.git;protocol=git;branch=master;rev=${SRCREV}"
 PR = "r2"

--- a/meta-oe/recipes-distros/openvix/softcams/oscam-trunk.inc
+++ b/meta-oe/recipes-distros/openvix/softcams/oscam-trunk.inc
@@ -4,5 +4,5 @@ EXTRA_OECMAKE += "\
 
 require oscam-common.inc
 
-PV = "1.20+svn"
-S = "${WORKDIR}/trunk"
+PV = "1.30+git"
+S = "${WORKDIR}/git"


### PR DESCRIPTION
oscam is now 1.30
in future when specifying versions, the commit ID will need to be specified 