### PR TITLE
[edid-decode] now uses meson

### DIFF
--- a/meta-oe/recipes-multimedia/edid-decode/edid-decode.bb
+++ b/meta-oe/recipes-multimedia/edid-decode/edid-decode.bb
@@ -14,4 +14,4 @@ SRC_URI = "git://git.linuxtv.org/edid-decode.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 
-inherit autotools-brokensep pkgconfig
+inherit meson pkgconfig


### PR DESCRIPTION
https://git.linuxtv.org/edid-decode.git/commit/?id=cdf81907def8658a66041a76ef2542e9a888cbed