### PR TITLE
Fix enigma2-skins dependencies

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-skins/enigma2-skins.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-skins/enigma2-skins.bb
@@ -28,7 +28,9 @@ SRC_URI:append = " \
 ALLOW_EMPTY:${PN} = "1"
 FILES:${PN} = "/usr/share/enigma2 /usr/share/fonts"
 FILES:${PN}-meta = "${datadir}/meta"
-RDEPENDS:${PN}-meta = ""
+RDEPENDS:${PN}-meta = " \
+    ${PYTHON_PN}-six \
+    "
 
 inherit autotools-brokensep
 


### PR DESCRIPTION
The patch that is applied a few lines above:
https://github.com/oe-alliance/oe-alliance-core/blob/153a3e9c0e99ae763fea2426270df45dd4e21d96/meta-oe/recipes-oe-alliance/enigma2-skins/enigma2-skins.bb#L17

Adds the python-six dependency.

Without the change I'm proposing, the build fails on this line:

https://github.com/oe-alliance/oe-alliance-core/blob/153a3e9c0e99ae763fea2426270df45dd4e21d96/meta-oe/recipes-oe-alliance/enigma2-skins/enigma2-skins/0001-make-genmetaindex-py2-py3-compatible.patch#L6

The build I'm running is:
```
MACHINE=vuuno4kse DISTRO=openatv DISTRO_TYPE=release make image
```