### PR TITLE
[Vu+ Kexec] - add Recovery script to /etc/init.d in devel branch for …

### DIFF
--- a/meta-oe/recipes-kernel/kexec/kexec-multiboot.bb
+++ b/meta-oe/recipes-kernel/kexec/kexec-multiboot.bb
@@ -10,14 +10,15 @@ SRCREV = "${AUTOREV}"
 PV = "git"
 PKGV = "${GITPKGVTAG}"
 
-SRC_URI="git://github.com/oe-alliance/kexec-multiboot.git;protocol=https;branch=main"
-
-S = "${WORKDIR}/git/${MACHINE}"
+SRC_URI = '${@bb.utils.contains_any("DISTRO_NAME", "openvix openbh", "git://github.com/oe-alliance/kexec-multiboot.git;protocol=https;branch=devel", "git://github.com/oe-alliance/kexec-multiboot.git;protocol=https;branch=main", d)}'
+S = "${WORKDIR}/git"
 
 do_install() {
     install -d ${D}${bindir}
-    install -m 0755 ${S}/kernel_auto.bin ${D}${bindir}/kernel_auto.bin
-    install -m 0755 ${S}/STARTUP_cpio.bin ${D}${bindir}/STARTUP.cpio.gz    
+    ${@bb.utils.contains_any("DISTRO_NAME", "openvix openbh", "install -d -m 0755 ${D}/etc/init.d", "", d)}    
+    install -m 0755 ${S}/${MACHINE}/kernel_auto.bin ${D}${bindir}/kernel_auto.bin
+    install -m 0755 ${S}/${MACHINE}/STARTUP_cpio.bin ${D}${bindir}/STARTUP.cpio.gz
+    ${@bb.utils.contains_any("DISTRO_NAME", "openvix openbh", "install -m 0755 ${S}/kexec-multiboot-recovery.sh ${D}/etc/init.d/kexec-multiboot-recovery.sh", "", d)}     
 }
 
 do_prepare_recipe_sysroot[noexec] = "1"


### PR DESCRIPTION
…openvix/openbh

If Vu+ Multiboot kernel issues (e.g. recently openpli et al) then this test script should recover kexec multiboot