### PR TITLE
[Vix  oscam] Add extended CW support

### DIFF
--- a/meta-oe/recipes-distros/openvix/softcams/oscam-common.inc
+++ b/meta-oe/recipes-distros/openvix/softcams/oscam-common.inc
@@ -37,6 +37,7 @@ EXTRA_OECMAKE += "\
 	-DMODULE_CONSTCW=1 \
 	-DMODULE_STREAMRELAY=1 \
 	-DHAVE_LIBDVBCSA=1 \
+	-DWITH_EXTENDED_CW=1 \
 "
 
 do_configure:prepend () {


### PR DESCRIPTION
Default is off user has to enableby adding the following to oscam.conf

```
[dvbapi]
pmt_mode                      = 6
extended_cw_api               = 1
```