### PR TITLE
Refactor package installation and removal scripts

### DIFF
--- a/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-iflatfhd.bb
+++ b/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-iflatfhd.bb
@@ -11,21 +11,35 @@ PV = "5.9+git"
 PKGV = "5.9+git${GITPKGV}"
 VER = "5.9"
 
-RDEPENDS:${PN} = "enigma2-plugin-systemplugins-weathercomponenthandler, enigma2-plugin-skincomponents-weathercomponent"
+RDEPENDS:${PN} = "enigma2-plugin-systemplugins-weathercomponenthandler enigma2-plugin-skincomponents-weathercomponent"
 
 SRC_URI = "git://github.com/openatv/iflat.git;protocol=https;branch=master"
 
-FILES:${PN} = "${libdir} /usr/share"
+FILES:${PN} += "${libdir} /usr/share"
 
 do_install() {
     install -d ${D}${libdir}
     install -d ${D}/usr/share
+
     cp -r --no-preserve=ownership ${S}/usr/lib/* ${D}${libdir}/
     cp -r --no-preserve=ownership ${S}/usr/share/* ${D}/usr/share/
+
     chmod -R a+rX ${D}/usr/share/enigma2/
 }
 
-pkg_postinst:${PN} () {
+pkg_preinst:${PN}() {
+#!/bin/sh
+echo "        iFlatFHD Skin will be now installed...            "
+exit 0
+}
+
+pkg_postinst:${PN}() {
+#!/bin/sh
+# Rootfs aşamasında başarısız olmaması için boş bırakılıyor.
+exit 0
+}
+
+pkg_postinst_ontarget:${PN}() {
 #!/bin/sh
 
 echo "********************************************************"
@@ -35,54 +49,65 @@ echo "*                  support by gordon55                 *"
 echo "********************************************************"
 
 iFlatDir="/usr/share/enigma2/iFlatFHD"
-widgetSP="skin_0ld-widgets.xml"                                                    # file name of the skinpart
-MPDir="/usr/lib/enigma2/python/Plugins/Extensions/MediaPortal"						
+widgetSP="skin_0ld-widgets.xml"
+MPDir="/usr/lib/enigma2/python/Plugins/Extensions/MediaPortal"
 
-if [ ! -d "$iFlatDir/mySkin_off" ]
-	then
-		mkdir "$iFlatDir/mySkin_off"
+if [ ! -d "$iFlatDir" ]; then
+    exit 0
 fi
 
-if [ -L "$iFlatDir/mySkin_off/$widgetSP" ]
-  then
-		echo -e "...skinpart for old constant-widgets is already active"
-  else
-		echo -e "..activate skinpart for old constant-widgets"
-		ln -sf "$iFlatDir/allScreens/$widgetSP" "$iFlatDir/mySkin_off/$widgetSP"
+if [ ! -d "$iFlatDir/mySkin_off" ]; then
+    mkdir -p "$iFlatDir/mySkin_off"
+fi
+
+if [ -L "$iFlatDir/mySkin_off/$widgetSP" ]; then
+    echo "...skinpart for old constant-widgets is already active"
+else
+    echo "...activate skinpart for old constant-widgets"
+    if [ -e "$iFlatDir/allScreens/$widgetSP" ]; then
+        ln -sf "$iFlatDir/allScreens/$widgetSP" "$iFlatDir/mySkin_off/$widgetSP"
+    fi
 fi
 
 echo "... checking activated skinparts"
 
 count=0
-for file in $iFlatDir/mySkin_off/*.xml
-do
-	#echo "--${file}--"
-	if [ ! -e "$file" ]; then
-		echo "    `basename "$file"` :  link broken, deleting"
-		rm -f "$file"
-		count=`expr $count + 1`
-	fi
+for file in "$iFlatDir"/mySkin_off/*.xml; do
+    if [ ! -e "$file" ]; then
+        echo "    $(basename "$file") : link broken, deleting"
+        rm -f "$file"
+        count=$((count + 1))
+    fi
 done
-[ $count == 0 ] && echo "    OK."
+
+[ "$count" = "0" ] && echo "    OK."
 
 echo
 
-if [ -e "${libdir}/enigma2/python/Plugins/Extensions/MediaPortal/plugin.pyo" ]
-  then
-		echo -e "... install iFlatFHD for Mediaportal"
-		[ -d "$MPDir/skins_1080/iFlatFHD" ] && rm -rf "$MPDir/skins_1080/iFlatFHD"
-		cp -raf "$iFlatDir/MediaPortal" "$MPDir/skins_1080/iFlatFHD"
-		mv "$MPDir/skins_1080/iFlatFHD/skin-MP.xml" "$MPDir/skins_1080/iFlatFHD/skin.xml"
-  else
-		echo -e "...   Mediaportal is not installed,\n     iFlatFHD for MP will not be installed"
+if [ -e "$MPDir/plugin.pyo" ] || [ -e "$MPDir/plugin.py" ]; then
+    echo "... install iFlatFHD for Mediaportal"
+    [ -d "$MPDir/skins_1080/iFlatFHD" ] && rm -rf "$MPDir/skins_1080/iFlatFHD"
+    mkdir -p "$MPDir/skins_1080"
+    cp -raf "$iFlatDir/MediaPortal" "$MPDir/skins_1080/iFlatFHD"
+    [ -e "$MPDir/skins_1080/iFlatFHD/skin-MP.xml" ] && mv "$MPDir/skins_1080/iFlatFHD/skin-MP.xml" "$MPDir/skins_1080/iFlatFHD/skin.xml"
+else
+    echo "... Mediaportal is not installed, iFlatFHD for MP will not be installed"
 fi
+
 echo "              ...Skin successful installed.                "
 exit 0
 }
 
-pkg_postrm:${PN} () {
+pkg_prerm:${PN}() {
 #!/bin/sh
-rm -rf /usr/share/enigma2/iFlatFHD
+echo "                                                           "
+echo "              iFlatFHD is now being removed...             "
+echo "                                                           "
+exit 0
+}
+
+pkg_postrm:${PN}() {
+#!/bin/sh
 
 echo "********************************************************"
 echo "*                      iFlatFHD                        *"
@@ -91,35 +116,20 @@ echo "*                 support by gordon55                  *"
 echo "********************************************************"
 echo ""
 
-# --- check if Mediaportal is installed. if yes, remove iFlatFHD skin for Mediaportal
+MPDir="/usr/lib/enigma2/python/Plugins/Extensions/MediaPortal"
 
-MPDir="${libdir}/enigma2/python/Plugins/Extensions/MediaPortal"
+rm -rf /usr/share/enigma2/iFlatFHD
 
-if [ -d "$MPDir/skins_1080/iFlatFHD" ]
-  then
-		echo -e ".. remove iFlatFHD skin for Mediaportal"
-		rm -rf "$MPDir/skins_1080/iFlatFHD"
-	else
-		echo -e "..   no iFlatFHD skin for Mediaportal found, nothing to do"
+if [ -d "$MPDir/skins_1080/iFlatFHD" ]; then
+    echo ".. remove iFlatFHD skin for Mediaportal"
+    rm -rf "$MPDir/skins_1080/iFlatFHD"
+else
+    echo ".. no iFlatFHD skin for Mediaportal found, nothing to do"
 fi
+
 echo "                                                           "
 echo "               ...Skin successful removed.                 "
 exit 0
 }
 
-pkg_preinst:${PN} () {
-#!/bin/sh
-echo "        iFlatFHD Skin will be now installed...            "
-exit 0
-}
-
-pkg_prerm:${PN} () {
-#!/bin/sh
-echo "                                                           "
-echo "              iFlatFHD is now being removed...             "
-echo "                                                           "
-exit 0
-}
-
 do_package_qa[noexec] = "1"
-


### PR DESCRIPTION
WARNING: openatv-image-8.0.0-alpha-20260314 do_rootfs: enigma2-plugin-skins-iflatfhd.postinst returned 1, marking as unpacked only, configuration required on target. ERROR: openatv-image-8.0.0-alpha-20260314 do_rootfs: Postinstall scriptlets of ['enigma2-plugin-skins-iflatfhd'] have failed. If the intention is to defer them to first boot, then please place them into pkg_postinst_ontarget:${PN} (). Deferring to first boot via 'exit 1' is no longer supported. Details of the failure are in /home/dreamosat/OpenATV/build-enviroment/builds/openatv/release/dreamtwo/tmp/work/dreamtwo-oe-linux/openatv-image/8.0.0-alpha/temp/log.do_rootfs. ERROR: Logfile of failure stored in: /home/dreamosat/OpenATV/build-enviroment/builds/openatv/release/dreamtwo/tmp/work/dreamtwo-oe-linux/openatv-image/8.0.0-alpha/temp/log.do_rootfs.417061 ERROR: Task (/home/dreamosat/OpenATV/build-enviroment/meta-oe-alliance/meta-oe/recipes-distros/openatv/image/openatv-image.bb:do_rootfs) failed with exit code '1'