### PR TITLE
[enigma2-plugin-systemplugins-servicehisilicon] Edit PR version format

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-systemplugins-servicehisilicon.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-systemplugins-servicehisilicon.bb
@@ -19,7 +19,7 @@ inherit autotools gitpkgv python3native pkgconfig python3targetconfig
 
 PV = "git"
 PKGV = "git${GITPKGV}"
-PR = ".3"
+PR = "r3"
 
 EXTRA_OECONF = " \
 	BUILD_SYS=${BUILD_SYS} \


### PR DESCRIPTION
enigma2-plugin-systemplugins-servicehisilicon_git26+1d4847a0+1d4847a4fa-.3_cortexa15hf-neon-vfpv4.ipk

"-.3" is not normal. Normal is "-r3" / PR = ".3" is not normal. Normal is PR = "r3" See: grep -r 'PR = "\.' ...build-enviroment/*

Please for 5.6 too. THX