### PR TITLE
[ABM] Delete provider.cache file prior to removal.

### DIFF
--- a/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-systemplugins-autobouquetsmaker.bb
+++ b/meta-oe/recipes-oe-alliance/enigma2-plugins/enigma2-plugin-systemplugins-autobouquetsmaker.bb
@@ -43,3 +43,11 @@ else
 	echo "No cache file found, continuing."
 fi
 }
+
+pkg_prerm:${PN}() {
+#!/bin/sh
+echo " Deleting ABM's providers.cache file because it will not be removed when uninstalling the plugin. It was not created by opkg."
+
+rm -f /usr/lib/enigma2/python/Plugins/SystemPlugins/AutoBouquetsMaker/providers/providers.cache
+
+}


### PR DESCRIPTION
As the cache file was never added by opkg, it used to prevent folder deletion.